### PR TITLE
feat: implement delete repository functionality with UI confirmation …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ CLOUDFLARE_TUNNEL_TOKEN="cloudflare_tunnel_token_placeholder"
 
 # Global organization registry
 REGISTRY_HOST=localhost:5000
+REGISTRY_INTERNAL_URL=http://registry:5000
 REGISTRY_TOKEN_REALM=http://localhost:8080/api/registry/token
 REGISTRY_TOKEN_ISSUER=cplane-registry
 REGISTRY_HTTP_SECRET=replace-with-a-long-random-registry-secret

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,6 +16,7 @@ services:
       CPLANE_SERVICE_TOKEN: ${CPLANE_SERVICE_TOKEN}
       STORAGE_ENDPOINT_URL: ${STORAGE_ENDPOINT_URL:-http://localhost:8081}
       REGISTRY_HOST: ${REGISTRY_HOST:-localhost:5000}
+      REGISTRY_INTERNAL_URL: ${REGISTRY_INTERNAL_URL:-http://registry:5000}
       REGISTRY_TOKEN_ISSUER: ${REGISTRY_TOKEN_ISSUER:-cplane-registry}
       REGISTRY_TOKEN_PRIVATE_KEY_PATH: /run/registry/registry-token-private.pem
       REGISTRY_TOKEN_CERTIFICATE_PATH: /run/registry/registry-token-public.pem

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,7 @@ services:
       CPLANE_SERVICE_TOKEN: ${CPLANE_SERVICE_TOKEN}
       STORAGE_ENDPOINT_URL: ${STORAGE_ENDPOINT_URL}
       REGISTRY_HOST: ${REGISTRY_HOST}
+      REGISTRY_INTERNAL_URL: ${REGISTRY_INTERNAL_URL:-http://registry:5000}
       REGISTRY_TOKEN_ISSUER: ${REGISTRY_TOKEN_ISSUER:-cplane-registry}
       REGISTRY_TOKEN_PRIVATE_KEY_PATH: /run/registry/registry-token-private.pem
       REGISTRY_TOKEN_CERTIFICATE_PATH: /run/registry/registry-token-public.pem

--- a/packages/api/src/handlers/registry.rs
+++ b/packages/api/src/handlers/registry.rs
@@ -117,11 +117,7 @@ pub async fn issue_token(
         jti: Uuid::new_v4().to_string(),
         access,
     };
-    let signer = registry_signer()?;
-    let mut jwt_header = Header::new(Algorithm::RS256);
-    jwt_header.x5c = Some(vec![signer.certificate.clone()]);
-    let token = encode(&jwt_header, &claims, &signer.key)
-        .map_err(|error| AppError::Internal(format!("Failed to sign registry token: {error}")))?;
+    let token = sign_registry_claims(&claims)?;
 
     Ok(Json(RegistryTokenResponse {
         access_token: token.clone(),
@@ -129,6 +125,38 @@ pub async fn issue_token(
         expires_in: TOKEN_TTL_SECONDS,
         issued_at: now.to_rfc3339(),
     }))
+}
+
+pub(crate) async fn sign_repository_token(
+    organization_id: Uuid,
+    repository_name: &str,
+    actions: &[&str],
+) -> Result<String, AppError> {
+    let organization_slug = organization_slug(organization_id).await?;
+    let now = chrono::Utc::now();
+    let issued_at = now.timestamp() as u64;
+    sign_registry_claims(&RegistryClaims {
+        iss: env::var("REGISTRY_TOKEN_ISSUER").unwrap_or_else(|_| "cplane-registry".into()),
+        sub: "cplane-control-plane".into(),
+        aud: env::var("REGISTRY_HOST").unwrap_or_else(|_| "localhost:5000".into()),
+        exp: issued_at + TOKEN_TTL_SECONDS,
+        nbf: issued_at.saturating_sub(5),
+        iat: issued_at,
+        jti: Uuid::new_v4().to_string(),
+        access: vec![RegistryAccess {
+            resource_type: "repository",
+            name: format!("{organization_slug}/{repository_name}"),
+            actions: actions.iter().map(|action| (*action).into()).collect(),
+        }],
+    })
+}
+
+fn sign_registry_claims(claims: &RegistryClaims) -> Result<String, AppError> {
+    let signer = registry_signer()?;
+    let mut jwt_header = Header::new(Algorithm::RS256);
+    jwt_header.x5c = Some(vec![signer.certificate.clone()]);
+    encode(&jwt_header, claims, &signer.key)
+        .map_err(|error| AppError::Internal(format!("Failed to sign registry token: {error}")))
 }
 
 fn parse_registry_token_query(raw_query: Option<&str>) -> Result<RegistryTokenQuery, AppError> {

--- a/packages/api/src/handlers/registry_repositories.rs
+++ b/packages/api/src/handlers/registry_repositories.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use axum::{Json, extract::Path, http::StatusCode};
 use reqwest::{Client, Url};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
@@ -129,6 +131,8 @@ pub async fn list_repositories(
         (status = 204, description = "Registry repository deleted"),
         (status = 403, description = "Organization access required"),
         (status = 404, description = "Registry repository not found"),
+        (status = 409, description = "Registry cleanup conflict"),
+        (status = 500, description = "Registry cleanup failed"),
     ),
     tag = "registry",
 )]
@@ -180,7 +184,12 @@ async fn delete_repository_images(
         std::env::var("REGISTRY_INTERNAL_URL").unwrap_or_else(|_| "http://registry:5000".into());
     let token =
         sign_repository_token(organization_id, repository_name, &["pull", "delete"]).await?;
-    let client = Client::new();
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| {
+            AppError::Internal(format!("Registry cleanup client setup failed: {error}"))
+        })?;
     let tags_url = registry_url(&base_url, repository_name, "tags/list")?;
     let response = client
         .get(tags_url)

--- a/packages/api/src/handlers/registry_repositories.rs
+++ b/packages/api/src/handlers/registry_repositories.rs
@@ -1,4 +1,5 @@
 use axum::{Json, extract::Path, http::StatusCode};
+use reqwest::{Client, Url};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -9,7 +10,17 @@ use crate::{
     errors::AppError, middleware::auth::AuthContext, models::entities::registry_repository,
 };
 
-use super::{databases::verify_org_access, registry_access_tokens::record_event};
+use super::{
+    databases::verify_org_access, registry::sign_repository_token,
+    registry_access_tokens::record_event,
+};
+
+const MANIFEST_ACCEPT: &str = "application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json";
+
+#[derive(Deserialize)]
+struct TagsResponse {
+    tags: Option<Vec<String>>,
+}
 
 #[derive(Deserialize, ToSchema)]
 pub struct CreateRegistryRepositoryRequest {
@@ -105,6 +116,158 @@ pub async fn list_repositories(
         .await?;
     scoped.commit().await?;
     Ok(Json(repositories.iter().map(response).collect()))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/organization/{organization_id}/registry/repositories/{repository_id}",
+    params(
+        ("organization_id" = Uuid, Path, description = "Organization ID"),
+        ("repository_id" = Uuid, Path, description = "Registry repository ID"),
+    ),
+    responses(
+        (status = 204, description = "Registry repository deleted"),
+        (status = 403, description = "Organization access required"),
+        (status = 404, description = "Registry repository not found"),
+    ),
+    tag = "registry",
+)]
+pub async fn delete_repository(
+    AuthContext { tenant_db, auth }: AuthContext,
+    Path((organization_id, repository_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, AppError> {
+    verify_org_access(&tenant_db, organization_id)?;
+    let scoped = tenant_db.begin_scoped_transaction().await?;
+    let tx = scoped.connection();
+    let repository = registry_repository::Entity::find_by_id(repository_id)
+        .filter(registry_repository::Column::OrganizationId.eq(organization_id))
+        .one(tx)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Registry repository not found".into()))?;
+    scoped.commit().await?;
+
+    delete_repository_images(&repository.name, organization_id).await?;
+
+    let scoped = tenant_db.begin_scoped_transaction().await?;
+    let tx = scoped.connection();
+    let repository = registry_repository::Entity::find_by_id(repository_id)
+        .filter(registry_repository::Column::OrganizationId.eq(organization_id))
+        .one(tx)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Registry repository not found".into()))?;
+
+    registry_repository::Entity::delete_by_id(repository.id)
+        .exec(tx)
+        .await?;
+    record_event(
+        tx,
+        organization_id,
+        auth.actor_id,
+        "registry-repository:deleted",
+        json!({ "summary": format!("Deleted registry repository '{}'", repository.name), "target_id": repository.id }),
+    )
+    .await?;
+    scoped.commit().await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn delete_repository_images(
+    repository_name: &str,
+    organization_id: Uuid,
+) -> Result<(), AppError> {
+    let base_url =
+        std::env::var("REGISTRY_INTERNAL_URL").unwrap_or_else(|_| "http://registry:5000".into());
+    let token =
+        sign_repository_token(organization_id, repository_name, &["pull", "delete"]).await?;
+    let client = Client::new();
+    let tags_url = registry_url(&base_url, repository_name, "tags/list")?;
+    let response = client
+        .get(tags_url)
+        .bearer_auth(&token)
+        .send()
+        .await
+        .map_err(|error| AppError::Internal(format!("Registry cleanup request failed: {error}")))?;
+    if response.status() == StatusCode::NOT_FOUND {
+        return Ok(());
+    }
+    if !response.status().is_success() {
+        return Err(AppError::Conflict(format!(
+            "Registry cleanup failed while listing tags: {}",
+            response.status()
+        )));
+    }
+    let tags = response
+        .json::<TagsResponse>()
+        .await
+        .map_err(|error| AppError::Internal(format!("Invalid registry tag response: {error}")))?
+        .tags
+        .unwrap_or_default();
+    let mut digests = std::collections::HashSet::new();
+    for tag in tags {
+        let manifest_url = registry_url(&base_url, repository_name, &format!("manifests/{tag}"))?;
+        let response = client
+            .head(manifest_url)
+            .header(reqwest::header::ACCEPT, MANIFEST_ACCEPT)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::Internal(format!("Registry cleanup request failed: {error}"))
+            })?;
+        if response.status() == StatusCode::NOT_FOUND {
+            continue;
+        }
+        if !response.status().is_success() {
+            return Err(AppError::Conflict(format!(
+                "Registry cleanup failed while resolving tag '{tag}': {}",
+                response.status()
+            )));
+        }
+        let digest = response
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok())
+            .ok_or_else(|| {
+                AppError::Conflict(format!(
+                    "Registry cleanup failed while resolving tag '{tag}': missing digest"
+                ))
+            })?;
+        digests.insert(digest.to_owned());
+    }
+    for digest in digests {
+        let manifest_url =
+            registry_url(&base_url, repository_name, &format!("manifests/{digest}"))?;
+        let response = client
+            .delete(manifest_url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::Internal(format!("Registry cleanup request failed: {error}"))
+            })?;
+        if !response.status().is_success() && response.status() != StatusCode::NOT_FOUND {
+            return Err(AppError::Conflict(format!(
+                "Registry cleanup failed while deleting image: {}",
+                response.status()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn registry_url(base_url: &str, repository_name: &str, suffix: &str) -> Result<Url, AppError> {
+    let mut url = Url::parse(base_url)
+        .map_err(|error| AppError::Internal(format!("Invalid registry URL: {error}")))?;
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|_| AppError::Internal("Registry URL cannot be a base URL".into()))?;
+        segments.push("v2");
+        segments.extend(repository_name.split('/'));
+        segments.extend(suffix.split('/'));
+    }
+    Ok(url)
 }
 
 fn response(repository: &registry_repository::Model) -> RegistryRepositoryResponse {

--- a/packages/api/src/openapi.rs
+++ b/packages/api/src/openapi.rs
@@ -52,6 +52,7 @@ use utoipa::OpenApi;
         crate::handlers::registry_access_tokens::update_access_token,
         crate::handlers::registry_repositories::create_repository,
         crate::handlers::registry_repositories::list_repositories,
+        crate::handlers::registry_repositories::delete_repository,
     ),
     components(
         schemas(

--- a/packages/api/src/routes/mod.rs
+++ b/packages/api/src/routes/mod.rs
@@ -28,6 +28,10 @@ pub fn create_routes() -> Router {
                 .post(registry_repositories::create_repository),
         )
         .route(
+            "/api/organization/{organization_id}/registry/repositories/{repository_id}",
+            delete(registry_repositories::delete_repository),
+        )
+        .route(
             "/api/organization/{organization_id}/registry/access-tokens",
             get(registry_access_tokens::list_access_tokens)
                 .post(registry_access_tokens::create_access_token),

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1949,6 +1949,47 @@
         }
       }
     },
+    "/api/organization/{organization_id}/registry/repositories/{repository_id}": {
+      "delete": {
+        "tags": [
+          "registry"
+        ],
+        "operationId": "delete_repository",
+        "parameters": [
+          {
+            "name": "organization_id",
+            "in": "path",
+            "description": "Organization ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "repository_id",
+            "in": "path",
+            "description": "Registry repository ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Registry repository deleted"
+          },
+          "403": {
+            "description": "Organization access required"
+          },
+          "404": {
+            "description": "Registry repository not found"
+          }
+        }
+      }
+    },
     "/api/organization/{organization_id}/storage/buckets": {
       "get": {
         "tags": [

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -55,6 +55,7 @@ export type Sdk = {
   registry: {
     create_access_token: Operation<"/api/organization/{organization_id}/registry/access-tokens", 'post'>
     create_repository: Operation<"/api/organization/{organization_id}/registry/repositories", 'post'>
+    delete_repository: Operation<"/api/organization/{organization_id}/registry/repositories/{repository_id}", 'delete'>
     get_access_token: Operation<"/api/organization/{organization_id}/registry/access-tokens/{token_id}", 'get'>
     issue_token: Operation<"/api/registry/token", 'get'>
     list_access_tokens: Operation<"/api/organization/{organization_id}/registry/access-tokens", 'get'>
@@ -124,6 +125,7 @@ export const createSdk = (options: SdkOptions = {}): Sdk => {
     registry: {
       create_access_token: (...args: Parameters<Operation<"/api/organization/{organization_id}/registry/access-tokens", 'post'>>) => client.POST("/api/organization/{organization_id}/registry/access-tokens", ...args),
       create_repository: (...args: Parameters<Operation<"/api/organization/{organization_id}/registry/repositories", 'post'>>) => client.POST("/api/organization/{organization_id}/registry/repositories", ...args),
+      delete_repository: (...args: Parameters<Operation<"/api/organization/{organization_id}/registry/repositories/{repository_id}", 'delete'>>) => client.DELETE("/api/organization/{organization_id}/registry/repositories/{repository_id}", ...args),
       get_access_token: (...args: Parameters<Operation<"/api/organization/{organization_id}/registry/access-tokens/{token_id}", 'get'>>) => client.GET("/api/organization/{organization_id}/registry/access-tokens/{token_id}", ...args),
       issue_token: (...args: Parameters<Operation<"/api/registry/token", 'get'>>) => client.GET("/api/registry/token", ...args),
       list_access_tokens: (...args: Parameters<Operation<"/api/organization/{organization_id}/registry/access-tokens", 'get'>>) => client.GET("/api/organization/{organization_id}/registry/access-tokens", ...args),

--- a/packages/sdk/src/generated.ts
+++ b/packages/sdk/src/generated.ts
@@ -324,6 +324,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/organization/{organization_id}/registry/repositories/{repository_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: operations["delete_repository"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/organization/{organization_id}/storage/buckets": {
         parameters: {
             query?: never;
@@ -2089,6 +2105,43 @@ export interface operations {
             };
             /** @description Invalid or duplicate repository name */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    delete_repository: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                organization_id: string;
+                /** @description Registry repository ID */
+                repository_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Registry repository deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Organization access required */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Registry repository not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/ui/app/pages/[organization_slug]/registry/index.vue
+++ b/packages/ui/app/pages/[organization_slug]/registry/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Repository } from '@cplane/sdk'
+import { FetchError } from 'ofetch'
 import { ICONS } from '~/utils/icons'
 
 defineOptions({ name: 'OrganizationRegistryPage' })
@@ -33,8 +34,9 @@ async function deleteRepository() {
     deleteModalOpen.value = false
     selectedRepository.value = null
     await refreshRepositories()
-  } catch {
-    toast.add({ title: 'Failed to delete repository and images', color: 'error' })
+  } catch (error) {
+    const message = error instanceof FetchError ? error.data?.message : undefined
+    toast.add({ title: message || 'Failed to delete repository and images', color: 'error' })
   } finally {
     deleting.value = false
   }

--- a/packages/ui/app/pages/[organization_slug]/registry/index.vue
+++ b/packages/ui/app/pages/[organization_slug]/registry/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Repository } from '@cplane/sdk'
 import { ICONS } from '~/utils/icons'
 
 defineOptions({ name: 'OrganizationRegistryPage' })
@@ -12,7 +13,32 @@ const registryHost = computed(() => config.public.registryHost)
 const repositoriesUrl = computed(() => organizationId.value
   ? `/api/cplane/organization/${organizationId.value as ':organization_id'}/registry/repositories` as const
   : '')
-const { data: repositories } = await useFetch(repositoriesUrl, { default: () => [] })
+const toast = useToast()
+const { data: repositories, refresh: refreshRepositories } = await useFetch(repositoriesUrl, { default: () => [] })
+const selectedRepository = ref<Repository | null>(null)
+const deleteModalOpen = ref(false)
+const deleting = ref(false)
+
+function confirmDelete(repository: Repository) {
+  selectedRepository.value = repository
+  deleteModalOpen.value = true
+}
+
+async function deleteRepository() {
+  if (!selectedRepository.value || !organizationId.value) return
+  deleting.value = true
+  try {
+    await $fetch(`/api/cplane/organization/${organizationId.value as ':organization_id'}/registry/repositories/${selectedRepository.value.id as ':repository_id'}` as const, { method: 'DELETE' })
+    toast.add({ title: 'Repository and images deleted', color: 'success' })
+    deleteModalOpen.value = false
+    selectedRepository.value = null
+    await refreshRepositories()
+  } catch {
+    toast.add({ title: 'Failed to delete repository and images', color: 'error' })
+  } finally {
+    deleting.value = false
+  }
+}
 </script>
 
 <template>
@@ -35,10 +61,25 @@ const { data: repositories } = await useFetch(repositoriesUrl, { default: () => 
     </div>
 
     <section v-for="repository in repositories" :key="repository.id" class="overflow-hidden rounded-lg border border-dashed border-default bg-transparent">
-      <div class="p-4">
-        <h2 class="font-semibold">{{ repository.name }}</h2>
-        <p class="mt-1 break-all font-mono text-xs text-muted">{{ registryHost }}/{{ organizationSlug }}/{{ repository.name }}</p>
+      <div class="flex items-center justify-between gap-3 border-b border-default p-4">
+        <div>
+          <h2 class="font-semibold">{{ repository.name }}</h2>
+          <p class="mt-1 break-all font-mono text-xs text-muted">{{ registryHost }}/{{ organizationSlug }}/{{ repository.name }}</p>
+        </div>
+        <UButton :icon="ICONS.trash" color="error" size="sm" @click="confirmDelete(repository)">Delete</UButton>
       </div>
     </section>
+
+    <UModal v-model:open="deleteModalOpen" title="Delete repository" description="This permanently deletes the repository images and access permissions.">
+      <template #body>
+        <div class="space-y-4">
+          <p class="text-sm">Are you sure you want to delete <strong>{{ selectedRepository?.name }}</strong>?</p>
+          <div class="flex justify-end gap-3 pt-2">
+            <UButton color="neutral" variant="ghost" :disabled="deleting" @click="deleteModalOpen = false">Cancel</UButton>
+            <UButton :icon="ICONS.trash" color="error" :loading="deleting" @click="deleteRepository">Delete</UButton>
+          </div>
+        </div>
+      </template>
+    </UModal>
   </div>
 </template>


### PR DESCRIPTION
## Summary

- Added repository deletion support to the Registry UI and API.
- Deletes all tagged image manifests from CNCF Distribution before removing the repository record.
- Cascades repository access permissions and records an audit event.
- Added internal registry URL configuration and regenerated the OpenAPI SDK.
- Added confirmation modal, loading state, success/error feedback, and list refresh.

## Notes

Registry blobs become eligible for garbage collection after manifest deletion; physical blob cleanup remains part of the registry’s separate GC workflow. #11 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete organization registry repositories from the registry management page.
  * Added a confirmation dialog, loading state, success/error notifications, and automatic list refresh after deletion.
  * Added SDK and API support for repository deletion, including access and not-found responses.
  * Registry cleanup now removes associated images when a repository is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->