### PR TITLE
Enhance organization management with permission checks and role-based access

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,8 +1,8 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@better-auth/cli@^1.4.21": "1.4.21_nanostores@1.4.1",
-    "npm:@better-auth/passkey@^1.6.23": "1.6.23_@better-auth+core@1.6.23__@better-auth+utils@0.4.2__@better-fetch+fetch@1.3.1__better-call@1.3.7___zod@4.4.3__jose@6.2.3__kysely@0.28.17__nanostores@1.4.1_@better-auth+utils@0.4.2_@better-fetch+fetch@1.3.1_better-auth@1.6.23__drizzle-kit@0.31.9__drizzle-orm@0.45.2___kysely@0.28.17___postgres@3.4.9__vue@3.5.40___typescript@5.9.3__postgres@3.4.9__typescript@5.9.3_better-call@1.3.7__zod@4.4.3_nanostores@1.4.1_jose@6.2.3_kysely@0.28.17",
+    "npm:@better-auth/cli@^1.4.21": "1.4.21_@types+node@25.9.1_vitest@3.2.7__@types+node@25.9.1",
+    "npm:@better-auth/passkey@^1.6.23": "1.6.23_better-auth@1.6.23__drizzle-kit@0.31.9__drizzle-orm@0.45.2___kysely@0.28.17___postgres@3.4.9__vitest@3.2.7___@types+node@25.9.1__@types+node@25.9.1_@types+node@25.9.1_vitest@3.2.7__@types+node@25.9.1",
     "npm:@iconify-json/heroicons-solid@^1.2.1": "1.2.1",
     "npm:@iconify-json/heroicons@^1.2.3": "1.2.3",
     "npm:@iconify-json/lucide@1.2.97": "1.2.97",
@@ -14,7 +14,7 @@
     "npm:@vue-flow/background@^1.3.2": "1.3.2_@vue-flow+core@1.48.2__vue@3.5.40___typescript@5.9.3__typescript@5.9.3_vue@3.5.40__typescript@5.9.3_typescript@5.9.3",
     "npm:@vue-flow/controls@^1.1.3": "1.1.3_@vue-flow+core@1.48.2__vue@3.5.40___typescript@5.9.3__typescript@5.9.3_vue@3.5.40__typescript@5.9.3_typescript@5.9.3",
     "npm:@vue-flow/core@^1.48.2": "1.48.2_vue@3.5.40__typescript@5.9.3_typescript@5.9.3",
-    "npm:better-auth@^1.6.23": "1.6.23_drizzle-kit@0.31.9_drizzle-orm@0.45.2__kysely@0.28.17__postgres@3.4.9_vue@3.5.40__typescript@5.9.3_postgres@3.4.9_typescript@5.9.3",
+    "npm:better-auth@^1.6.23": "1.6.23_drizzle-kit@0.31.9_drizzle-orm@0.45.2__kysely@0.28.17__postgres@3.4.9_vitest@3.2.7__@types+node@25.9.1_@types+node@25.9.1",
     "npm:drizzle-kit@1.0.0-rc.4": "1.0.0-rc.4",
     "npm:drizzle-orm@1.0.0-rc.4": "1.0.0-rc.4_postgres@3.4.9_zod@4.4.3",
     "npm:eslint@^10.7.0": "10.7.0_jiti@2.7.0",
@@ -31,6 +31,7 @@
     "npm:tailwindcss@^4.3.3": "4.3.3",
     "npm:typescript@^5.9.3": "5.9.3",
     "npm:uuidv7@^1.2.1": "1.2.1",
+    "npm:vitest@^3.2.4": "3.2.7_@types+node@25.9.1",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "npm": {
@@ -41,7 +42,7 @@
       "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
       "dependencies": [
         "package-manager-detector",
-        "tinyexec"
+        "tinyexec@1.2.4"
       ]
     },
     "@apidevtools/json-schema-ref-parser@14.2.1_@types+json-schema@7.0.15": {
@@ -342,7 +343,7 @@
         "@babel/helper-validator-identifier@8.0.4"
       ]
     },
-    "@better-auth/cli@1.4.21_nanostores@1.4.1": {
+    "@better-auth/cli@1.4.21_@types+node@25.9.1_vitest@3.2.7__@types+node@25.9.1": {
       "integrity": "sha512-bKEa8BupnZxNjLk9ZDntvgQGm5jogeE2wHdMbYifhet3GTyxgDi6pXoOK8+aqHYQGg1C3OALi9hVVWnrv7JJWQ==",
       "dependencies": [
         "@babel/core",
@@ -355,7 +356,7 @@
         "@mrleebo/prisma-ast",
         "@prisma/client",
         "@types/pg",
-        "better-auth@1.4.21_@prisma+client@5.22.0_better-sqlite3@12.10.0_drizzle-kit@0.31.9_drizzle-orm@0.41.0__@prisma+client@5.22.0__@types+pg@8.20.0__better-sqlite3@12.10.0__kysely@0.28.17__pg@8.21.0__postgres@3.4.9_pg@8.21.0",
+        "better-auth@1.4.21_@prisma+client@5.22.0_better-sqlite3@12.10.0_drizzle-kit@0.31.9_drizzle-orm@0.41.0__@prisma+client@5.22.0__@types+pg@8.20.0__better-sqlite3@12.10.0__kysely@0.28.17__pg@8.21.0__postgres@3.4.9_pg@8.21.0_vitest@3.2.7__@types+node@25.9.1_@types+node@25.9.1",
         "better-sqlite3",
         "c12",
         "chalk",
@@ -448,7 +449,7 @@
         "@better-auth/utils@0.4.2"
       ]
     },
-    "@better-auth/passkey@1.6.23_@better-auth+core@1.6.23__@better-auth+utils@0.4.2__@better-fetch+fetch@1.3.1__better-call@1.3.7___zod@4.4.3__jose@6.2.3__kysely@0.28.17__nanostores@1.4.1_@better-auth+utils@0.4.2_@better-fetch+fetch@1.3.1_better-auth@1.6.23__drizzle-kit@0.31.9__drizzle-orm@0.45.2___kysely@0.28.17___postgres@3.4.9__vue@3.5.40___typescript@5.9.3__postgres@3.4.9__typescript@5.9.3_better-call@1.3.7__zod@4.4.3_nanostores@1.4.1_jose@6.2.3_kysely@0.28.17": {
+    "@better-auth/passkey@1.6.23_better-auth@1.6.23__drizzle-kit@0.31.9__drizzle-orm@0.45.2___kysely@0.28.17___postgres@3.4.9__vitest@3.2.7___@types+node@25.9.1__@types+node@25.9.1_@types+node@25.9.1_vitest@3.2.7__@types+node@25.9.1": {
       "integrity": "sha512-nr5tKaNd/huUwTYX4DUm4HcXgBkixj0lXrRHdy9azY4fFjF49Tyif4sPyRMWnQJYxlRJ1HVEMJq2nGyr5CLXQg==",
       "dependencies": [
         "@better-auth/core@1.6.23_@better-auth+utils@0.4.2_@better-fetch+fetch@1.3.1_better-call@1.3.7__zod@4.4.3_jose@6.2.3_kysely@0.28.17_nanostores@1.4.1",
@@ -456,7 +457,7 @@
         "@better-fetch/fetch@1.3.1",
         "@simplewebauthn/browser",
         "@simplewebauthn/server",
-        "better-auth@1.6.23_drizzle-kit@0.31.9_drizzle-orm@0.45.2__kysely@0.28.17__postgres@3.4.9_vue@3.5.40__typescript@5.9.3_postgres@3.4.9_typescript@5.9.3",
+        "better-auth@1.6.23_drizzle-kit@0.31.9_drizzle-orm@0.45.2__kysely@0.28.17__postgres@3.4.9_vitest@3.2.7__@types+node@25.9.1_@types+node@25.9.1",
         "better-call@1.3.7_zod@4.4.3",
         "nanostores",
         "zod"
@@ -582,7 +583,7 @@
         "nostics@0.2.0_@types+node@25.9.1_jiti@2.7.0",
         "pathe@2.0.3",
         "perfect-debounce@2.1.0",
-        "tinyexec"
+        "tinyexec@1.2.4"
       ]
     },
     "@drizzle-team/brocli@0.10.2": {
@@ -1227,7 +1228,7 @@
       "dependencies": [
         "ansis",
         "bundle-require",
-        "cac",
+        "cac@7.0.0",
         "chokidar",
         "esbuild@0.27.7",
         "eslint",
@@ -1516,9 +1517,9 @@
         "scule",
         "semver@7.8.5",
         "srvx",
-        "std-env",
+        "std-env@4.2.0",
         "tinyclip",
-        "tinyexec",
+        "tinyexec@1.2.4",
         "ufo",
         "youch"
       ],
@@ -1679,7 +1680,7 @@
         "mlly",
         "ohash",
         "picomatch@4.0.5",
-        "std-env",
+        "std-env@4.2.0",
         "tinyglobby",
         "ufo"
       ]
@@ -1761,7 +1762,7 @@
         "ohash",
         "pathe@2.0.3",
         "rou3@0.9.1",
-        "std-env",
+        "std-env@4.2.0",
         "ufo",
         "unctx@3.0.0_magic-string@0.30.21_rolldown@1.2.0_unplugin@2.3.11",
         "unstorage",
@@ -1778,7 +1779,7 @@
         "nostics@1.2.0",
         "pathe@2.0.3",
         "pkg-types@2.3.1",
-        "std-env"
+        "std-env@4.2.0"
       ]
     },
     "@nuxt/telemetry@2.8.0_@nuxt+kit@4.5.0__@types+node@25.9.1__magic-string@1.0.0__rolldown@1.2.0__unplugin@3.3.0___esbuild@0.28.0___rolldown@1.2.0___rollup@4.60.4___vite@8.1.5____@types+node@25.9.1____esbuild@0.28.0____jiti@2.7.0___@types+node@25.9.1___jiti@2.7.0__vite@8.1.5___@types+node@25.9.1___esbuild@0.27.7___jiti@2.7.0_magic-string@1.0.0_rolldown@1.2.0_unplugin@3.3.0__esbuild@0.28.0__rolldown@1.2.0__rollup@4.60.4__vite@8.1.5___@types+node@25.9.1___esbuild@0.28.0___jiti@2.7.0__@types+node@25.9.1__jiti@2.7.0": {
@@ -1789,7 +1790,7 @@
         "consola",
         "ofetch@2.0.0-alpha.3",
         "rc9",
-        "std-env"
+        "std-env@4.2.0"
       ],
       "bin": true
     },
@@ -1893,11 +1894,11 @@
         "rolldown@1.2.0",
         "rolldown-string",
         "seroval",
-        "std-env",
+        "std-env@4.2.0",
         "ufo",
         "unenv",
         "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0",
-        "vite-node",
+        "vite-node@6.0.0_@types+node@25.9.1_jiti@2.7.0",
         "vite-plugin-checker",
         "vue",
         "vue-bundle-renderer"
@@ -3330,6 +3331,16 @@
         "tslib@2.8.1"
       ]
     },
+    "@types/chai@5.2.3": {
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dependencies": [
+        "@types/deep-eql",
+        "assertion-error"
+      ]
+    },
+    "@types/deep-eql@4.0.2": {
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="
+    },
     "@types/esrecurse@4.3.1": {
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="
     },
@@ -3651,7 +3662,7 @@
         "nostics@1.2.0",
         "pathe@2.0.3",
         "perfect-debounce@2.1.0",
-        "tinyexec",
+        "tinyexec@1.2.4",
         "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0"
       ]
     },
@@ -3673,6 +3684,64 @@
         "@rolldown/pluginutils",
         "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0",
         "vue"
+      ]
+    },
+    "@vitest/expect@3.2.7": {
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dependencies": [
+        "@types/chai",
+        "@vitest/spy",
+        "@vitest/utils",
+        "chai",
+        "tinyrainbow"
+      ]
+    },
+    "@vitest/mocker@3.2.7_vite@7.3.6__@types+node@25.9.1_@types+node@25.9.1": {
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dependencies": [
+        "@vitest/spy",
+        "estree-walker@3.0.3",
+        "magic-string@0.30.21",
+        "vite@7.3.6_@types+node@25.9.1"
+      ],
+      "optionalPeers": [
+        "vite@7.3.6_@types+node@25.9.1"
+      ]
+    },
+    "@vitest/pretty-format@3.2.7": {
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dependencies": [
+        "tinyrainbow"
+      ]
+    },
+    "@vitest/runner@3.2.7": {
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dependencies": [
+        "@vitest/utils",
+        "pathe@2.0.3",
+        "strip-literal"
+      ]
+    },
+    "@vitest/snapshot@3.2.7": {
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dependencies": [
+        "@vitest/pretty-format",
+        "magic-string@0.30.21",
+        "pathe@2.0.3"
+      ]
+    },
+    "@vitest/spy@3.2.7": {
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dependencies": [
+        "tinyspy"
+      ]
+    },
+    "@vitest/utils@3.2.7": {
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dependencies": [
+        "@vitest/pretty-format",
+        "loupe",
+        "tinyrainbow"
       ]
     },
     "@vue-flow/background@1.3.2_@vue-flow+core@1.48.2__vue@3.5.40___typescript@5.9.3__typescript@5.9.3_vue@3.5.40__typescript@5.9.3_typescript@5.9.3": {
@@ -4023,6 +4092,9 @@
         "tslib@2.8.1"
       ]
     },
+    "assertion-error@2.0.1": {
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="
+    },
     "ast-kit@2.2.0": {
       "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
       "dependencies": [
@@ -4111,7 +4183,7 @@
       "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "bin": true
     },
-    "better-auth@1.4.21_@prisma+client@5.22.0_better-sqlite3@12.10.0_drizzle-kit@0.31.9_drizzle-orm@0.41.0__@prisma+client@5.22.0__@types+pg@8.20.0__better-sqlite3@12.10.0__kysely@0.28.17__pg@8.21.0__postgres@3.4.9_pg@8.21.0": {
+    "better-auth@1.4.21_@prisma+client@5.22.0_better-sqlite3@12.10.0_drizzle-kit@0.31.9_drizzle-orm@0.41.0__@prisma+client@5.22.0__@types+pg@8.20.0__better-sqlite3@12.10.0__kysely@0.28.17__pg@8.21.0__postgres@3.4.9_pg@8.21.0_vitest@3.2.7__@types+node@25.9.1_@types+node@25.9.1": {
       "integrity": "sha512-qdrIZS7xnGF2HPBV5wYNPWTkPojhauOOjz1+MhLvwFy+zXpgLofQmWsI5I9DY+ef845NKt93XcgpyAc4RPPT9A==",
       "dependencies": [
         "@better-auth/core@1.4.21_@better-auth+utils@0.3.0_@better-fetch+fetch@1.1.21_better-call@1.1.8__zod@4.4.3_jose@6.2.3_kysely@0.28.17_nanostores@1.4.1",
@@ -4130,6 +4202,7 @@
         "kysely",
         "nanostores",
         "pg",
+        "vitest",
         "vue",
         "zod"
       ],
@@ -4139,13 +4212,14 @@
         "drizzle-kit@0.31.9",
         "drizzle-orm@0.41.0_@prisma+client@5.22.0_@types+pg@8.20.0_better-sqlite3@12.10.0_kysely@0.28.17_pg@8.21.0_postgres@3.4.9",
         "pg",
+        "vitest",
         "vue"
       ]
     },
-    "better-auth@1.6.23_drizzle-kit@0.31.9_drizzle-orm@0.45.2__kysely@0.28.17__postgres@3.4.9_vue@3.5.40__typescript@5.9.3_postgres@3.4.9_typescript@5.9.3": {
+    "better-auth@1.6.23_drizzle-kit@0.31.9_drizzle-orm@0.45.2__kysely@0.28.17__postgres@3.4.9_vitest@3.2.7__@types+node@25.9.1_@types+node@25.9.1": {
       "integrity": "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==",
       "dependencies": [
-        "@better-auth/core@1.6.23_@better-auth+utils@0.4.2_@better-fetch+fetch@1.3.1_better-call@1.3.7__zod@4.4.3_jose@6.2.3_kysely@0.28.17_nanostores@1.4.0",
+        "@better-auth/core@1.6.23_@better-auth+utils@0.4.2_@better-fetch+fetch@1.3.1_better-call@1.3.7__zod@4.4.3_jose@6.2.3_kysely@0.28.17_nanostores@1.4.1",
         "@better-auth/drizzle-adapter",
         "@better-auth/kysely-adapter",
         "@better-auth/memory-adapter",
@@ -4163,12 +4237,14 @@
         "jose",
         "kysely",
         "nanostores",
+        "vitest",
         "vue",
         "zod"
       ],
       "optionalPeers": [
         "drizzle-kit@0.31.9",
         "drizzle-orm@0.45.2_kysely@0.28.17_postgres@3.4.9",
+        "vitest",
         "vue"
       ]
     },
@@ -4315,6 +4391,9 @@
         "magicast"
       ]
     },
+    "cac@6.7.14": {
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="
+    },
     "cac@7.0.0": {
       "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="
     },
@@ -4331,11 +4410,24 @@
     "caniuse-lite@1.0.30001806": {
       "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw=="
     },
+    "chai@5.3.3": {
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dependencies": [
+        "assertion-error",
+        "check-error",
+        "deep-eql",
+        "loupe",
+        "pathval"
+      ]
+    },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
     },
     "change-case@5.4.4": {
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="
+    },
+    "check-error@2.1.3": {
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="
     },
     "chevrotain@10.5.0": {
       "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
@@ -4666,6 +4758,9 @@
         "mimic-response"
       ]
     },
+    "deep-eql@5.0.2": {
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="
+    },
     "deep-extend@0.6.0": {
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
@@ -4711,7 +4806,7 @@
       "dependencies": [
         "@valibot/to-json-schema",
         "birpc@4.0.0",
-        "cac",
+        "cac@7.0.0",
         "h3@2.0.1-rc.22",
         "mrmime",
         "nostics@0.2.0_@types+node@25.9.1_jiti@2.7.0",
@@ -4927,6 +5022,9 @@
     },
     "es-errors@1.3.0": {
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-module-lexer@1.7.0": {
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
     },
     "es-module-lexer@2.1.0": {
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="
@@ -5355,6 +5453,9 @@
     "expand-template@2.0.3": {
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
+    "expect-type@1.4.0": {
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="
+    },
     "exsolve@1.1.0": {
       "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw=="
     },
@@ -5722,7 +5823,7 @@
       "integrity": "sha512-5AUn+QE0UofqNHu5f2Skf6Svukdg4ehOIq8O0EtqIx4jta0CDZYBPqpIHt0zrlUTiFVYlLpeH39DoikXBjPKpA==",
       "dependencies": [
         "@jridgewell/trace-mapping",
-        "es-module-lexer",
+        "es-module-lexer@2.1.0",
         "pathe@2.0.3",
         "unplugin@3.3.0_esbuild@0.28.0_rolldown@1.2.0_rollup@4.60.4_vite@8.1.5__@types+node@25.9.1__esbuild@0.28.0__jiti@2.7.0_@types+node@25.9.1_jiti@2.7.0",
         "unplugin-utils"
@@ -6065,7 +6166,7 @@
         "mlly",
         "node-forge",
         "pathe@2.0.3",
-        "std-env",
+        "std-env@4.2.0",
         "tinyclip",
         "ufo",
         "untun",
@@ -6110,6 +6211,9 @@
     },
     "lodash@4.17.21": {
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "loupe@3.2.1": {
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="
     },
     "lru-cache@10.4.3": {
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
@@ -6372,7 +6476,7 @@
         "serve-placeholder",
         "serve-static",
         "source-map@0.7.6",
-        "std-env",
+        "std-env@4.2.0",
         "ufo",
         "ultrahtml",
         "uncrypto",
@@ -6508,7 +6612,7 @@
         "rou3@0.9.1",
         "scule",
         "semver@7.8.5",
-        "std-env",
+        "std-env@4.2.0",
         "tinyglobby",
         "ufo",
         "ultrahtml",
@@ -6533,7 +6637,7 @@
       "dependencies": [
         "citty@0.2.2",
         "pathe@2.0.3",
-        "tinyexec"
+        "tinyexec@1.2.4"
       ],
       "bin": true
     },
@@ -6801,6 +6905,9 @@
     },
     "pathe@2.0.3": {
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
+    },
+    "pathval@2.0.1": {
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="
     },
     "perfect-debounce@1.0.0": {
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="
@@ -7721,6 +7828,9 @@
     "shell-quote@1.8.4": {
       "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="
     },
+    "siginfo@2.0.0": {
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
+    },
     "signal-exit@3.0.7": {
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
@@ -7807,11 +7917,17 @@
     "stable-hash-x@0.2.0": {
       "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="
     },
+    "stackback@0.0.2": {
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
+    },
     "standard-as-callback@2.1.0": {
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses@2.0.2": {
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+    },
+    "std-env@3.10.0": {
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="
     },
     "std-env@4.2.0": {
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="
@@ -8014,8 +8130,14 @@
     "tiny-invariant@1.3.3": {
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
+    "tinybench@2.9.0": {
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="
+    },
     "tinyclip@0.1.15": {
       "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A=="
+    },
+    "tinyexec@0.3.2": {
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
     "tinyexec@1.2.4": {
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="
@@ -8026,6 +8148,15 @@
         "fdir",
         "picomatch@4.0.5"
       ]
+    },
+    "tinypool@1.1.1": {
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="
+    },
+    "tinyrainbow@2.0.0": {
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="
+    },
+    "tinyspy@4.0.4": {
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="
     },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -8432,7 +8563,6 @@
       "integrity": "sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A==",
       "dependencies": [
         "birpc@2.9.0",
-        "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0",
         "vite-hot-client"
       ]
     },
@@ -8442,11 +8572,22 @@
         "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0"
       ]
     },
+    "vite-node@3.2.4_@types+node@25.9.1": {
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dependencies": [
+        "cac@6.7.14",
+        "debug",
+        "es-module-lexer@1.7.0",
+        "pathe@2.0.3",
+        "vite@7.3.6_@types+node@25.9.1"
+      ],
+      "bin": true
+    },
     "vite-node@6.0.0_@types+node@25.9.1_jiti@2.7.0": {
       "integrity": "sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==",
       "dependencies": [
-        "cac",
-        "es-module-lexer",
+        "cac@7.0.0",
+        "es-module-lexer@2.1.0",
         "obug",
         "pathe@2.0.3",
         "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0"
@@ -8483,7 +8624,6 @@
         "perfect-debounce@2.1.0",
         "sirv",
         "unplugin-utils",
-        "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0",
         "vite-dev-rpc"
       ]
     },
@@ -8498,6 +8638,25 @@
         "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0",
         "vue"
       ]
+    },
+    "vite@7.3.6_@types+node@25.9.1": {
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dependencies": [
+        "@types/node",
+        "esbuild@0.28.0",
+        "fdir",
+        "picomatch@4.0.5",
+        "postcss",
+        "rollup",
+        "tinyglobby"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ],
+      "bin": true
     },
     "vite@8.1.5_@types+node@25.9.1_esbuild@0.27.7_jiti@2.7.0": {
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
@@ -8560,6 +8719,39 @@
         "@types/node",
         "jiti",
         "yaml"
+      ],
+      "bin": true
+    },
+    "vitest@3.2.7_@types+node@25.9.1": {
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dependencies": [
+        "@types/chai",
+        "@types/node",
+        "@vitest/expect",
+        "@vitest/mocker",
+        "@vitest/pretty-format",
+        "@vitest/runner",
+        "@vitest/snapshot",
+        "@vitest/spy",
+        "@vitest/utils",
+        "chai",
+        "debug",
+        "expect-type",
+        "magic-string@0.30.21",
+        "pathe@2.0.3",
+        "picomatch@4.0.5",
+        "std-env@3.10.0",
+        "tinybench",
+        "tinyexec@0.3.2",
+        "tinyglobby",
+        "tinypool",
+        "tinyrainbow",
+        "vite@7.3.6_@types+node@25.9.1",
+        "vite-node@3.2.4_@types+node@25.9.1",
+        "why-is-node-running"
+      ],
+      "optionalPeers": [
+        "@types/node"
       ],
       "bin": true
     },
@@ -8672,6 +8864,14 @@
       "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dependencies": [
         "isexe@4.0.0"
+      ],
+      "bin": true
+    },
+    "why-is-node-running@2.3.0": {
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dependencies": [
+        "siginfo",
+        "stackback"
       ],
       "bin": true
     },
@@ -8906,6 +9106,7 @@
             "npm:tailwindcss@^4.3.3",
             "npm:typescript@^5.9.3",
             "npm:uuidv7@^1.2.1",
+            "npm:vitest@^3.2.4",
             "npm:zod@^4.4.3"
           ]
         }

--- a/packages/api/src/middleware/auth.rs
+++ b/packages/api/src/middleware/auth.rs
@@ -4,8 +4,9 @@ use reqwest::Client;
 use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
-use std::{collections::HashSet, sync::OnceLock};
+use std::sync::OnceLock;
 use uuid::Uuid;
 
 use crate::errors::AppError;
@@ -22,26 +23,67 @@ fn reqwest_client() -> &'static Client {
     })
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OrganizationRole {
+    Owner,
+    Member,
+}
+
+#[derive(Clone, Debug)]
+pub struct OrganizationAccess {
+    pub role: OrganizationRole,
+    pub scopes: HashSet<String>,
+}
+
+impl OrganizationAccess {
+    pub fn allows(&self, scope: &str) -> bool {
+        self.role == OrganizationRole::Owner || self.scopes.contains(scope)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct RequestAuthContext {
     pub actor_id: Uuid,
-    api_key_scopes: Option<HashSet<String>>,
+    organizations: HashMap<Uuid, OrganizationAccess>,
 }
 
 impl RequestAuthContext {
-    pub fn require_scope(&self, scope: &str) -> Result<(), AppError> {
-        if self
-            .api_key_scopes
-            .as_ref()
-            .is_none_or(|scopes| scopes.contains(scope))
-        {
+    pub fn is_owner(&self, organization_id: Uuid) -> bool {
+        self.organizations
+            .get(&organization_id)
+            .is_some_and(|access| access.role == OrganizationRole::Owner)
+    }
+
+    pub fn has_scope(&self, organization_id: Uuid, scope: &str) -> bool {
+        self.organizations
+            .get(&organization_id)
+            .is_some_and(|access| access.allows(scope))
+    }
+
+    pub fn require_scope(&self, organization_id: Uuid, scope: &str) -> Result<(), AppError> {
+        if self.has_scope(organization_id, scope) {
             return Ok(());
         }
-
         Err(AppError::Forbidden(format!(
-            "API key is missing required scope: {scope}"
+            "Missing required permission: {scope}"
         )))
     }
+
+    #[allow(dead_code)]
+    pub fn require_owner(&self, organization_id: Uuid) -> Result<(), AppError> {
+        if self.is_owner(organization_id) {
+            return Ok(());
+        }
+        Err(AppError::Forbidden(
+            "Only organization owners can perform this action".to_string(),
+        ))
+    }
+}
+
+fn organization_id_from_path(path: &str) -> Option<Uuid> {
+    let rest = path.strip_prefix("/api/organization/")?;
+    let segment = rest.split('/').next()?;
+    Uuid::parse_str(segment).ok()
 }
 
 pub(crate) fn required_scope(method: &str, path: &str) -> Option<&'static str> {
@@ -192,8 +234,25 @@ pub(crate) fn required_scope(method: &str, path: &str) -> Option<&'static str> {
         ("DELETE", "/api/organization/{organization_id}/registry/access-tokens/{token_id}") => {
             "access-token:delete"
         }
+        ("GET", "/api/organization/{organization_id}/registry/maintenance") => "registry:read",
         _ => return None,
     })
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RoutePolicy {
+    Public,
+    Scope(&'static str),
+    OwnerOnly,
+}
+
+pub(crate) fn route_policy(method: &str, path: &str) -> RoutePolicy {
+    let method = if method == "HEAD" { "GET" } else { method };
+    match required_scope(method, path) {
+        Some(scope) => RoutePolicy::Scope(scope),
+        None if path.starts_with("/api/organization/") => RoutePolicy::OwnerOnly,
+        None => RoutePolicy::Public,
+    }
 }
 
 pub struct AuthContext {
@@ -218,6 +277,13 @@ struct ApiKeyLookup {
     scopes: HashSet<String>,
 }
 
+#[derive(Debug)]
+struct MemberLookup {
+    organization_id: Uuid,
+    role: String,
+    scopes: HashSet<String>,
+}
+
 impl<S> FromRequestParts<S> for AuthContext
 where
     S: Send + Sync,
@@ -225,10 +291,11 @@ where
     type Rejection = AppError;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        let required_scope = parts
+        let policy = parts
             .extensions
             .get::<MatchedPath>()
-            .and_then(|path| required_scope(parts.method.as_str(), path.as_str()));
+            .map(|path| route_policy(parts.method.as_str(), path.as_str()))
+            .unwrap_or(RoutePolicy::Public);
         let state = get_app_state();
         let identity_db = state.identity_db;
         let tenant_db_conn = state.tenant_db;
@@ -239,13 +306,21 @@ where
             let api_key: ApiKeyLookup = resolve_api_key(&identity_db, &raw_api_key)
                 .await?
                 .ok_or_else(|| AppError::Unauthorized("Invalid API key".to_string()))?;
+            let mut organizations = HashMap::new();
+            organizations.insert(
+                api_key.organization_id,
+                OrganizationAccess {
+                    role: OrganizationRole::Member,
+                    scopes: api_key.scopes,
+                },
+            );
             (
                 OrganizationContext {
                     allowed_organizations: vec![api_key.organization_id],
                 },
                 RequestAuthContext {
                     actor_id: api_key.id,
-                    api_key_scopes: Some(api_key.scopes),
+                    organizations,
                 },
             )
         } else {
@@ -255,12 +330,29 @@ where
                 .and_then(|h| h.to_str().ok())
                 .ok_or_else(|| AppError::Unauthorized("Missing session cookie".to_string()))?;
             let actor_id = resolve_user_from_cookie(cookie_header).await?;
-            let allowed_organizations = resolve_user_organizations(&identity_db, actor_id).await?;
+            let memberships = resolve_user_memberships(&identity_db, actor_id).await?;
 
-            if allowed_organizations.is_empty() {
+            if memberships.is_empty() {
                 return Err(AppError::Forbidden(
                     "User has no organization access".to_string(),
                 ));
+            }
+
+            let mut organizations = HashMap::new();
+            let mut allowed_organizations = Vec::with_capacity(memberships.len());
+            for membership in memberships {
+                allowed_organizations.push(membership.organization_id);
+                organizations.insert(
+                    membership.organization_id,
+                    OrganizationAccess {
+                        role: if membership.role == "owner" {
+                            OrganizationRole::Owner
+                        } else {
+                            OrganizationRole::Member
+                        },
+                        scopes: membership.scopes,
+                    },
+                );
             }
 
             (
@@ -269,13 +361,19 @@ where
                 },
                 RequestAuthContext {
                     actor_id,
-                    api_key_scopes: None,
+                    organizations,
                 },
             )
         };
 
-        if let Some(scope) = required_scope {
-            request_auth.require_scope(scope)?;
+        if policy != RoutePolicy::Public {
+            let organization_id = organization_id_from_path(parts.uri.path()).ok_or_else(|| {
+                AppError::Forbidden("Route requires an organization context".to_string())
+            })?;
+            match policy {
+                RoutePolicy::Scope(scope) => request_auth.require_scope(organization_id, scope)?,
+                _ => request_auth.require_owner(organization_id)?,
+            }
         }
 
         let tenant_db = TenantDatabase::new(tenant_db_conn, organization_context);
@@ -361,29 +459,41 @@ fn hash_api_key(raw_api_key: &str) -> String {
     hex::encode(hasher.finalize())
 }
 
-async fn resolve_user_organizations(
+async fn resolve_user_memberships(
     app_db: &AppDatabase,
     actor_id: Uuid,
-) -> Result<Vec<Uuid>, AppError> {
+) -> Result<Vec<MemberLookup>, AppError> {
     let rows = app_db
         .0
         .query_all(Statement::from_sql_and_values(
             DatabaseBackend::Postgres,
-            "SELECT organization_id FROM organization_member WHERE user_id = $1",
+            "SELECT m.organization_id, m.role, COALESCE(array_agg(p.scope::text) FILTER (WHERE p.scope IS NOT NULL), ARRAY[]::text[]) AS scopes FROM organization_member m LEFT JOIN organization_member_permission p ON p.member_id = m.id WHERE m.user_id = $1 GROUP BY m.id, m.organization_id, m.role",
             vec![actor_id.into()],
         ))
         .await
         .map_err(|err| AppError::Internal(err.to_string()))?;
 
-    let mut organizations = Vec::with_capacity(rows.len());
+    let mut memberships = Vec::with_capacity(rows.len());
     for row in rows {
-        let org_id = row
+        let organization_id = row
             .try_get::<Uuid>("", "organization_id")
             .map_err(|err| AppError::Internal(err.to_string()))?;
-        organizations.push(org_id);
+        let role = row
+            .try_get::<String>("", "role")
+            .map_err(|err| AppError::Internal(err.to_string()))?;
+        let scopes = row
+            .try_get::<Vec<String>>("", "scopes")
+            .map_err(|err| AppError::Internal(err.to_string()))?
+            .into_iter()
+            .collect();
+        memberships.push(MemberLookup {
+            organization_id,
+            role,
+            scopes,
+        });
     }
 
-    Ok(organizations)
+    Ok(memberships)
 }
 
 async fn resolve_api_key(
@@ -427,24 +537,135 @@ async fn resolve_api_key(
 
 #[cfg(test)]
 mod tests {
-    use super::RequestAuthContext;
-    use std::collections::HashSet;
+    use super::{OrganizationAccess, OrganizationRole, RequestAuthContext};
+    use std::collections::HashMap;
     use uuid::Uuid;
 
-    #[test]
-    fn api_key_scope_checks_fail_closed_while_sessions_bypass_them() {
-        let session = RequestAuthContext {
+    fn context(
+        organizations: Vec<(Uuid, OrganizationRole, &[&str])>,
+    ) -> RequestAuthContext {
+        let mut map = HashMap::new();
+        for (id, role, scopes) in organizations {
+            map.insert(
+                id,
+                OrganizationAccess {
+                    role,
+                    scopes: scopes.iter().map(|s| s.to_string()).collect(),
+                },
+            );
+        }
+        RequestAuthContext {
             actor_id: Uuid::nil(),
-            api_key_scopes: None,
-        };
-        assert!(session.require_scope("project:delete").is_ok());
+            organizations: map,
+        }
+    }
 
-        let scoped_key = RequestAuthContext {
-            actor_id: Uuid::nil(),
-            api_key_scopes: Some(HashSet::from(["project:read".into()])),
-        };
-        assert!(scoped_key.require_scope("project:read").is_ok());
-        assert!(scoped_key.require_scope("project:delete").is_err());
+    #[test]
+    fn api_keys_are_scope_limited_members_of_one_organization() {
+        let org = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let key = context(vec![(org, OrganizationRole::Member, &["project:read"])]);
+
+        assert!(key.require_scope(org, "project:read").is_ok());
+        assert!(key.require_scope(org, "project:delete").is_err());
+        assert!(!key.is_owner(org), "api keys are never owners");
+
+        assert!(key.require_scope(other, "project:read").is_err());
+    }
+
+    #[test]
+    fn members_are_enforced_against_their_granted_scopes() {
+        let org = Uuid::new_v4();
+        let member = context(vec![
+            (org, OrganizationRole::Member, &["container:read", "bucket:read"]),
+        ]);
+
+        assert!(member.has_scope(org, "container:read"));
+        assert!(member.require_scope(org, "container:create").is_err());
+
+        let promoted = context(vec![
+            (
+                org,
+                OrganizationRole::Member,
+                &["container:read", "container:create"],
+            ),
+        ]);
+        assert!(promoted.require_scope(org, "container:create").is_ok());
+    }
+
+    #[test]
+    fn owners_hold_every_scope_and_pass_owner_checks() {
+        let org = Uuid::new_v4();
+        let owner = context(vec![(org, OrganizationRole::Owner, &[])]);
+
+        for scope in [
+            "project:delete",
+            "registry:update",
+            "database:postgres:manage",
+            "org:update",
+        ] {
+            assert!(owner.require_scope(org, scope).is_ok(), "{scope}");
+        }
+        assert!(owner.require_owner(org).is_ok());
+    }
+
+    #[test]
+    fn members_fail_owner_checks_even_with_scopes() {
+        let org = Uuid::new_v4();
+        let member = context(vec![(
+            org,
+            OrganizationRole::Member,
+            &[
+                "org:update",
+                "member:invite",
+                "member:remove",
+                "api-key:manage",
+            ],
+        )]);
+
+        assert!(member.require_owner(org).is_err());
+    }
+
+    #[test]
+    fn access_is_isolated_per_organization() {
+        let org_a = Uuid::new_v4();
+        let org_b = Uuid::new_v4();
+        let user = context(vec![
+            (org_a, OrganizationRole::Owner, &[]),
+            (org_b, OrganizationRole::Member, &["project:read"]),
+        ]);
+
+        assert!(user.is_owner(org_a));
+        assert!(user.require_scope(org_b, "project:read").is_ok());
+        assert!(user.require_scope(org_b, "project:delete").is_err());
+        assert!(user.require_owner(org_b).is_err());
+    }
+
+    #[test]
+    fn unknown_organizations_fail_closed() {
+        let org = Uuid::new_v4();
+        let stranger = context(vec![]);
+        assert!(stranger.require_scope(org, "project:read").is_err());
+        assert!(stranger.require_owner(org).is_err());
+        assert!(!stranger.is_owner(org));
+    }
+
+    #[test]
+    fn organization_id_parses_from_request_paths() {
+        let id = Uuid::new_v4();
+        assert_eq!(
+            super::organization_id_from_path(&format!("/api/organization/{id}/projects")),
+            Some(id)
+        );
+        assert_eq!(
+            super::organization_id_from_path(&format!("/api/organization/{id}")),
+            Some(id)
+        );
+        assert_eq!(super::organization_id_from_path("/health"), None);
+        assert_eq!(
+            super::organization_id_from_path("/api/organization/not-a-uuid/projects"),
+            None
+        );
     }
 
     #[test]
@@ -720,15 +941,56 @@ mod tests {
             );
         }
 
-        for (method, path) in [
-            ("GET", "/health"),
-            ("GET", "/api/registry/token"),
-            (
-                "GET",
-                "/api/organization/{organization_id}/registry/maintenance",
-            ),
-        ] {
+        for (method, path) in [("GET", "/health"), ("GET", "/api/registry/token")] {
             assert_eq!(super::required_scope(method, path), None, "{method} {path}");
         }
+    }
+
+    #[test]
+    fn route_policy_fails_closed_and_normalizes_head() {
+        use super::{RoutePolicy, route_policy};
+
+        assert_eq!(
+            route_policy("GET", "/api/organization/{organization_id}/projects"),
+            RoutePolicy::Scope("project:read")
+        );
+        assert_eq!(
+            route_policy(
+                "DELETE",
+                "/api/organization/{organization_id}/containers/{container_id}"
+            ),
+            RoutePolicy::Scope("container:delete")
+        );
+
+        assert_eq!(
+            route_policy("HEAD", "/api/organization/{organization_id}/projects"),
+            RoutePolicy::Scope("project:read")
+        );
+
+        assert_eq!(
+            route_policy("GET", "/api/organization/{organization_id}/registry/maintenance"),
+            RoutePolicy::Scope("registry:read")
+        );
+
+        assert_eq!(
+            route_policy(
+                "GET",
+                "/api/organization/{organization_id}/something-new"
+            ),
+            RoutePolicy::OwnerOnly
+        );
+        assert_eq!(
+            route_policy(
+                "POST",
+                "/api/organization/{organization_id}/registry/maintenance/run"
+            ),
+            RoutePolicy::OwnerOnly
+        );
+
+        assert_eq!(route_policy("GET", "/health"), RoutePolicy::Public);
+        assert_eq!(
+            route_policy("GET", "/api/registry/token"),
+            RoutePolicy::Public
+        );
     }
 }

--- a/packages/migrations/drizzle/20260822125335_uneven_freak/migration.sql
+++ b/packages/migrations/drizzle/20260822125335_uneven_freak/migration.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "organization_member_permission_scope_type" AS ENUM('region:read', 'project:read', 'project:create', 'project:delete', 'project:manage', 'access-token:read', 'access-token:create', 'access-token:update', 'access-token:delete', 'bucket:read', 'bucket:create', 'bucket:delete', 'timeline:read', 'event:read', 'container:read', 'container:create', 'container:update', 'container:delete', 'database:postgres:read', 'database:postgres:create', 'database:postgres:update', 'database:postgres:delete', 'database:postgres:manage', 'registry:read', 'registry:create', 'registry:update', 'registry:delete', 'org:update', 'member:invite', 'member:remove', 'api-key:manage');--> statement-breakpoint
+CREATE TABLE "organization_member_permission" (
+	"id" uuid PRIMARY KEY,
+	"member_id" uuid NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"scope" "organization_member_permission_scope_type" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "organization_member_permission" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE UNIQUE INDEX "organization_member_permission_member_id_scope_uidx" ON "organization_member_permission" ("member_id","scope");--> statement-breakpoint
+CREATE INDEX "organization_member_permission_organization_id_idx" ON "organization_member_permission" ("organization_id");--> statement-breakpoint
+CREATE INDEX "organization_member_permission_member_id_idx" ON "organization_member_permission" ("member_id");--> statement-breakpoint
+ALTER TABLE "organization_member_permission" ADD CONSTRAINT "organization_member_permission_lSLy26ie0K9a_fkey" FOREIGN KEY ("member_id") REFERENCES "organization_member"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "organization_member_permission" ADD CONSTRAINT "organization_member_permission_DCAxdTDApsJo_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE;--> statement-breakpoint
+CREATE POLICY "organization_member_permission_tenant_rls" ON "organization_member_permission" AS PERMISSIVE FOR ALL TO "app_tenant" USING ("organization_member_permission"."organization_id" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))) WITH CHECK ("organization_member_permission"."organization_id" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[])));

--- a/packages/migrations/drizzle/20260822125335_uneven_freak/snapshot.json
+++ b/packages/migrations/drizzle/20260822125335_uneven_freak/snapshot.json
@@ -1,0 +1,8375 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "1920d452-8bee-45b4-b5f4-9f97debe5307",
+  "prevIds": [
+    "da9f63fa-f73b-4d8b-8e86-3f66a78af5e3"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "region:read",
+        "project:read",
+        "project:create",
+        "project:delete",
+        "project:manage",
+        "access-token:read",
+        "access-token:create",
+        "access-token:update",
+        "access-token:delete",
+        "bucket:read",
+        "bucket:create",
+        "bucket:delete",
+        "timeline:read",
+        "event:read",
+        "container:read",
+        "container:create",
+        "container:update",
+        "container:delete",
+        "database:postgres:read",
+        "database:postgres:create",
+        "database:postgres:update",
+        "database:postgres:delete",
+        "database:postgres:manage",
+        "registry:read",
+        "registry:create",
+        "registry:update",
+        "registry:delete"
+      ],
+      "name": "api_key_scopes_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "provisioning",
+        "ready",
+        "deleting",
+        "failed"
+      ],
+      "name": "bucket_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "healthy",
+        "degraded",
+        "offline"
+      ],
+      "name": "cluster_health_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "healthy",
+        "degraded",
+        "unreachable"
+      ],
+      "name": "cluster_ingress_endpoint_health_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "aws",
+        "gcp",
+        "azure",
+        "metal"
+      ],
+      "name": "cluster_provider",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "bootstrapping",
+        "healthy",
+        "draining",
+        "offline",
+        "removed"
+      ],
+      "name": "cluster_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "revoked"
+      ],
+      "name": "organization_invitation_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "region:read",
+        "project:read",
+        "project:create",
+        "project:delete",
+        "project:manage",
+        "access-token:read",
+        "access-token:create",
+        "access-token:update",
+        "access-token:delete",
+        "bucket:read",
+        "bucket:create",
+        "bucket:delete",
+        "timeline:read",
+        "event:read",
+        "container:read",
+        "container:create",
+        "container:update",
+        "container:delete",
+        "database:postgres:read",
+        "database:postgres:create",
+        "database:postgres:update",
+        "database:postgres:delete",
+        "database:postgres:manage",
+        "registry:read",
+        "registry:create",
+        "registry:update",
+        "registry:delete",
+        "org:update",
+        "member:invite",
+        "member:remove",
+        "api-key:manage"
+      ],
+      "name": "organization_member_permission_scope_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "active",
+        "draining",
+        "disabled"
+      ],
+      "name": "region_routing_mode",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "active",
+        "inactive",
+        "maintenance"
+      ],
+      "name": "region_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "aws_s3",
+        "cloudflare_r2"
+      ],
+      "name": "s3_provider_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "account",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "active_organization",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "api_key_scopes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "api_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "bucket",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "clusters",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "cluster_ingress_endpoints",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "cluster_join_credentials",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "container",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "container_version",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "event",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "external_registry",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "infrastructure_audit_log",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization_invitation",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization_member",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization_member_permission",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "passkey",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "postgres_database",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "postgres_database_branch",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "project",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "project_environment",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "project_timeline",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "regions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "registry_access_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "registry_maintenance",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "registry_repositories",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "registry_repository_grants",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "registry_storage",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "s3_providers",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "storage_access_token",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "storage_access_token_bucket",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "two_factor",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verification",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "worker_job",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "pg_catalog.gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "active_organization"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "active_organization"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "api_key_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "type": "api_key_scopes_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "allowed_ips",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "region_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "type": "bucket_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "region_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_endpoint",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "cluster_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "cluster_provider",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'aws'",
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "capacity_allocatable",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "capacity_used",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "cluster_health_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'healthy'",
+      "generated": null,
+      "identity": null,
+      "name": "health_status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "agent_last_seen_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cluster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "443",
+      "generated": null,
+      "identity": null,
+      "name": "port",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "cluster_ingress_endpoint_health_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'healthy'",
+      "generated": null,
+      "identity": null,
+      "name": "health_status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_seen_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cluster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "used_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "region_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "container_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "public",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "replica_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "port",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "env",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "env_secret_refs",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resources",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "external_registry_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "health_check",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "type": "json",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "system",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "host",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_identifier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_ip",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "changes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "type": "organization_invitation_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "member_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "type": "organization_member_permission_scope_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "pg_catalog.gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "counter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transports",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "default_branch_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "database_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "branch_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "30",
+      "generated": null,
+      "identity": null,
+      "name": "backup_retention_days",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cpu",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ram",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "high_availability",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "read_replicas",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "autoscaling_enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "autoscaling_min_cpu",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "autoscaling_max_cpu",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "default_environment_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "is_preview",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "draft_timeline",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deployed_timeline",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "environment_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "timeline",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parent_timeline_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "pins",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "s3_provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "type": "region_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "type": "region_routing_mode",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "routing_mode",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'distribution'",
+      "generated": null,
+      "identity": null,
+      "name": "service",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gc_access_key_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'idle'",
+      "generated": null,
+      "identity": null,
+      "name": "phase",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_job_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_result",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "can_pull",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "can_push",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'distribution'",
+      "generated": null,
+      "identity": null,
+      "name": "service",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bucket_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "physical_bucket_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_key_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "type": "s3_provider_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "endpoint_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_region",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_key_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bucket_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "can_read",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "can_write",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "pg_catalog.gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "two_factor"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "secret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "two_factor"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backup_codes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "two_factor"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "two_factor"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "pg_catalog.gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "two_factor_enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "pg_catalog.gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verification"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verification"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verification"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verification"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "job_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'queued'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dedupe_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "3",
+      "generated": null,
+      "identity": null,
+      "name": "max_attempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locked_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lease_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "account_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "active_organization_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "active_organization"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "api_key_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_key_scopes_api_key_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "scope",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_key_scopes_scope_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_key_scopes_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_keys_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "key_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_keys_key_hash_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "bucket_name_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "bucket_project_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "bucket_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "region_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "bucket_region_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "region_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "clusters_region_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "agent_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "clusters_agent_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "clusters_slug_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "clusters_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "health_status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "clusters_health_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "clusters_provider_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "cluster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "address",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cluster_ingress_endpoints_cluster_id_address_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "cluster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cluster_ingress_endpoints_cluster_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "health_status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cluster_ingress_endpoints_health_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "enabled",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cluster_ingress_endpoints_enabled_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "cluster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cluster_join_credentials_cluster_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cluster_join_credentials_expires_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cluster_join_credentials_token_hash_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "container_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "container_project_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "container_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "container_version_container_id_version_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "container_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "container_version_container_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "container_version_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "external_registry_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "container_version_external_registry_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_type_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_project_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "external_registry_organization_name_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "host",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "username",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "external_registry_organization_host_username_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "external_registry_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "infrastructure_audit_log_created_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "resource_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "resource_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "infrastructure_audit_log_resource_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_slug_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_invitation_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_invitation_email_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_member_user_id_organization_id_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_member_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_member_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "member_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "scope",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_member_permission_member_id_scope_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_member_permission_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "member_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_member_permission_member_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "passkey_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "passkey_credentialID_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "postgres_database_project_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "postgres_database_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "database_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "postgres_database_branch_database_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "branch_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "postgres_database_branch_branch_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "postgres_database_branch_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_organization_id_name_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_id_organization_id_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "default_environment_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_default_environment_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_environment_project_id_name_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_environment_id_project_id_organization_id_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_environment_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_environment_project_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_timeline_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "environment_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_timeline_environment_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_timeline_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_timeline_project_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "parent_timeline_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "project_timeline_parent_timeline_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "regions_slug_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "regions_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "routing_mode",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "regions_routing_mode_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "s3_provider_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "regions_s3_provider_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_access_tokens_hash_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"revoked_at\" is null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_access_tokens_organization_name_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_access_tokens_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "active_job_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_maintenance_active_job_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_repositories_organization_name_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_repositories_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "access_token_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "repository_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_repository_grants_token_repository_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_repository_grants_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_repository_grants_repository_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "access_token_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_repository_grants_access_token_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "service",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_storage_service_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "bucket_name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_storage_bucket_name_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "physical_bucket_name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_storage_physical_bucket_name_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "access_key_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_storage_access_key_id_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "registry_storage_provider_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "s3_providers_provider_type_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "is_active",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "s3_providers_is_active_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "access_key_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "storage_access_token_access_key_id_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"revoked_at\" is null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "storage_access_token_project_name_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "storage_access_token_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "storage_access_token_project_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "access_token_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "bucket_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "storage_access_token_bucket_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "access_token_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "storage_access_token_bucket_token_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "bucket_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "storage_access_token_bucket_bucket_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "secret",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "twoFactor_secret_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "two_factor"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "twoFactor_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "two_factor"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "verification"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "worker_job_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "queue_name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "available_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "worker_job_claim_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "lease_expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "worker_job_lease_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "queue_name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dedupe_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"dedupe_key\" is not null and \"status\" in ('queued', 'running')",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "worker_job_active_dedupe_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "account_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "account"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "active_organization_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "active_organization"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "active_organization_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "active_organization"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "api_key_scopes_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "api_key_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "api_keys",
+      "columnsTo": [
+        "id",
+        "organization_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "api_key_scopes_api_key_scope_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "api_keys_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "project_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "bucket_project_id_project_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "bucket_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "region_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "regions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "bucket_region_id_regions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "region_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "regions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "clusters_region_id_regions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "clusters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "cluster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "clusters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "cluster_ingress_endpoints_cluster_id_clusters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "cluster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "clusters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "cluster_join_credentials_cluster_id_clusters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cluster_join_credentials"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "project_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_container_project_id_project_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_container_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "region_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "regions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "project_container_region_id_regions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "container_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "container",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_container_version_G9mjmkAY7GFU_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_container_version_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "external_registry_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "external_registry",
+      "columnsTo": [
+        "id",
+        "organization_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "container_version_external_registry_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "external_registry_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_invitation_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_invitation_inviter_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_member_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_member_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "member_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization_member",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_member_permission_lSLy26ie0K9a_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_member_permission_DCAxdTDApsJo_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "passkey_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "passkey"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "project_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "postgres_database_project_id_project_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "postgres_database_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "default_branch_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "postgres_database_branch",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "postgres_database_sQcvj8ruZ82p_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "database_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "postgres_database",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "postgres_database_branch_database_id_postgres_database_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "branch_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project_environment",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "postgres_database_branch_branch_id_project_environment_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "postgres_database_branch_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "default_environment_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project_environment",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "project_default_environment_id_project_environment_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "project_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_environment_project_id_project_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_environment_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "draft_timeline"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project_timeline",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "project_environment_draft_timeline_project_timeline_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "deployed_timeline"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project_timeline",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "project_environment_deployed_timeline_project_timeline_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "project_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_timeline_project_id_project_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "project_timeline_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "parent_timeline_id",
+        "project_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project_timeline",
+      "columnsTo": [
+        "id",
+        "project_id",
+        "organization_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "project_timeline_parent_scope_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "s3_provider_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "s3_providers",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "regions_s3_provider_id_s3_providers_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "registry_access_tokens_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "active_job_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "worker_job",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "registry_maintenance_active_job_id_worker_job_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "registry_repositories_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "registry_repository_grants_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "repository_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "registry_repositories",
+      "columnsTo": [
+        "id",
+        "organization_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "registry_repository_grants_repository_scope_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "access_token_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "registry_access_tokens",
+      "columnsTo": [
+        "id",
+        "organization_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "registry_repository_grants_token_scope_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "provider_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "s3_providers",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "registry_storage_provider_id_s3_providers_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "storage_access_token_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "project_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "storage_access_token_project_id_project_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "storage_access_token_bucket_vSGyhrH3NafP_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "access_token_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "storage_access_token",
+      "columnsTo": [
+        "id",
+        "organization_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "storage_access_token_bucket_token_scope_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "bucket_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "bucket",
+      "columnsTo": [
+        "id",
+        "organization_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "storage_access_token_bucket_bucket_scope_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "two_factor_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "two_factor"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "worker_job_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_pkey",
+      "schema": "public",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "active_organization_pkey",
+      "schema": "public",
+      "table": "active_organization",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "api_key_scopes_pkey",
+      "schema": "public",
+      "table": "api_key_scopes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "api_keys_pkey",
+      "schema": "public",
+      "table": "api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "bucket_pkey",
+      "schema": "public",
+      "table": "bucket",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "clusters_pkey",
+      "schema": "public",
+      "table": "clusters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cluster_ingress_endpoints_pkey",
+      "schema": "public",
+      "table": "cluster_ingress_endpoints",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cluster_join_credentials_pkey",
+      "schema": "public",
+      "table": "cluster_join_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_container_pkey",
+      "schema": "public",
+      "table": "container",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_container_version_pkey",
+      "schema": "public",
+      "table": "container_version",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_pkey",
+      "schema": "public",
+      "table": "event",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "external_registry_pkey",
+      "schema": "public",
+      "table": "external_registry",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "infrastructure_audit_log_pkey",
+      "schema": "public",
+      "table": "infrastructure_audit_log",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_pkey",
+      "schema": "public",
+      "table": "organization",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_invitation_pkey",
+      "schema": "public",
+      "table": "organization_invitation",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_member_pkey",
+      "schema": "public",
+      "table": "organization_member",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_member_permission_pkey",
+      "schema": "public",
+      "table": "organization_member_permission",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "passkey_pkey",
+      "schema": "public",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "postgres_database_pkey",
+      "schema": "public",
+      "table": "postgres_database",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "postgres_database_branch_pkey",
+      "schema": "public",
+      "table": "postgres_database_branch",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_pkey",
+      "schema": "public",
+      "table": "project",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_environment_pkey",
+      "schema": "public",
+      "table": "project_environment",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_timeline_pkey",
+      "schema": "public",
+      "table": "project_timeline",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "regions_pkey",
+      "schema": "public",
+      "table": "regions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "registry_access_tokens_pkey",
+      "schema": "public",
+      "table": "registry_access_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "service"
+      ],
+      "nameExplicit": false,
+      "name": "registry_maintenance_pkey",
+      "schema": "public",
+      "table": "registry_maintenance",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "registry_repositories_pkey",
+      "schema": "public",
+      "table": "registry_repositories",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "registry_repository_grants_pkey",
+      "schema": "public",
+      "table": "registry_repository_grants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "registry_storage_pkey",
+      "schema": "public",
+      "table": "registry_storage",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "s3_providers_pkey",
+      "schema": "public",
+      "table": "s3_providers",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "storage_access_token_pkey",
+      "schema": "public",
+      "table": "storage_access_token",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "two_factor_pkey",
+      "schema": "public",
+      "table": "two_factor",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_pkey",
+      "schema": "public",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verification_pkey",
+      "schema": "public",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "worker_job_pkey",
+      "schema": "public",
+      "table": "worker_job",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "id",
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "api_keys_id_organization_id_uidx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "id",
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "bucket_id_organization_id_uidx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "id",
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "external_registry_id_organization_id_uidx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "id",
+        "project_id",
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "project_timeline_parent_scope_uidx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "id",
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "registry_access_tokens_id_organization_id_uidx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "id",
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "registry_repositories_id_organization_id_uidx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "id",
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "storage_access_token_id_organization_id_uidx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "active_organization_user_id_key",
+      "schema": "public",
+      "table": "active_organization",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "clusters_slug_key",
+      "schema": "public",
+      "table": "clusters",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "agent_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "clusters_agent_id_key",
+      "schema": "public",
+      "table": "clusters",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_email_key",
+      "schema": "public",
+      "table": "organization",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_slug_key",
+      "schema": "public",
+      "table": "organization",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "regions_slug_key",
+      "schema": "public",
+      "table": "regions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gc_access_key_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "registry_maintenance_gc_access_key_id_key",
+      "schema": "public",
+      "table": "registry_maintenance",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_email_key",
+      "schema": "public",
+      "table": "user",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"phase\" in ('idle', 'queued', 'draining', 'collecting', 'restoring')",
+      "name": "registry_maintenance_phase_check",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "value": "\"status\" in ('queued', 'running', 'succeeded', 'failed')",
+      "name": "worker_job_status_check",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "value": "\"attempts\" >= 0 and \"max_attempts\" > 0",
+      "name": "worker_job_attempts_check",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "worker_job"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"active_organization\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"active_organization\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "active_organization_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "active_organization"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"api_key_scopes\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"api_key_scopes\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "api_key_scopes_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "api_key_scopes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"api_keys\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"api_keys\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "api_keys_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "api_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"bucket\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"bucket\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "bucket_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "bucket"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"container\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"container\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "container_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "container"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"container_version\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"container_version\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "container_version_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "container_version"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"event\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"event\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "event_org_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "event"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"external_registry\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"external_registry\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "external_registry_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "external_registry"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "app_audit_reader"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "infrastructure_audit_log_reader",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "infrastructure_audit_log"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"organization\".\"id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": null,
+      "name": "organization_tenant_rls_select",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"organization\".\"id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"organization\".\"id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "organization_tenant_rls_update",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"organization\".\"id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": null,
+      "name": "organization_tenant_rls_delete",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "organization_tenant_rls_insert",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "organization"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"organization_invitation\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"organization_invitation\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "organization_invitation_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "organization_invitation"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"organization_member\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"organization_member\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "organization_member_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "organization_member"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"organization_member_permission\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"organization_member_permission\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "organization_member_permission_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "organization_member_permission"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"postgres_database\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"postgres_database\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "postgres_database_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "postgres_database"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"postgres_database_branch\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"postgres_database_branch\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "postgres_database_branch_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "postgres_database_branch"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"project\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"project\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "project_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "project"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"project_environment\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"project_environment\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "project_environment_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "project_environment"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"project_timeline\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"project_timeline\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "project_timeline_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "project_timeline"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "regions_tenant_select_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "regions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"registry_access_tokens\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"registry_access_tokens\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "registry_access_tokens_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "registry_access_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "registry_maintenance_tenant_select_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "registry_maintenance"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"registry_repositories\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"registry_repositories\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "registry_repositories_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "registry_repositories"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"registry_repository_grants\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"registry_repository_grants\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "registry_repository_grants_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "registry_repository_grants"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "registry_storage_tenant_select_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "registry_storage"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "s3_providers_tenant_select_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "s3_providers"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"storage_access_token\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"storage_access_token\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "storage_access_token_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "storage_access_token"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "app_tenant"
+      ],
+      "using": "\"storage_access_token_bucket\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "withCheck": "\"storage_access_token_bucket\".\"organization_id\" = ANY(COALESCE(NULLIF(current_setting('app.allowed_organizations', true), '')::uuid[], ARRAY[]::uuid[]))",
+      "name": "storage_access_token_bucket_tenant_rls",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "storage_access_token_bucket"
+    }
+  ],
+  "renames": []
+}

--- a/packages/migrations/schema/events.ts
+++ b/packages/migrations/schema/events.ts
@@ -4,7 +4,7 @@ import type { EventType } from "../utils/event-types.ts";
 export type { EventType } from "../utils/event-types.ts";
 import { app_tenant, orgAllowed } from "./rls.ts";
 
-export const event = pgTable("event", {
+export const event = pgTable.withRLS("event", {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id")
   .notNull()
@@ -26,4 +26,4 @@ export const event = pgTable("event", {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/infrastructure/audit.ts
+++ b/packages/migrations/schema/infrastructure/audit.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 import { index, jsonb, pgPolicy, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { app_audit_reader } from "../rls.ts";
 
-export const infrastructure_audit_log = pgTable("infrastructure_audit_log", {
+export const infrastructure_audit_log = pgTable.withRLS("infrastructure_audit_log", {
   id: uuid("id").primaryKey(),
   actor_identifier: text("actor_identifier").notNull(),
   source_ip: text("source_ip").notNull(),
@@ -20,4 +20,4 @@ export const infrastructure_audit_log = pgTable("infrastructure_audit_log", {
     to: app_audit_reader,
     using: sql`true`,
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/infrastructure/clusters.ts
+++ b/packages/migrations/schema/infrastructure/clusters.ts
@@ -8,7 +8,7 @@ export const cluster_health_status = pgEnum("cluster_health_status", ["healthy",
 export const cluster_provider = pgEnum("cluster_provider", ["aws", "gcp", "azure", "metal"]);
 export const cluster_ingress_endpoint_health_status = pgEnum("cluster_ingress_endpoint_health_status", ["healthy", "degraded", "unreachable"]);
 
-export const cluster = pgTable("clusters", {
+export const cluster = pgTable.withRLS("clusters", {
   id: uuid("id").primaryKey(),
   region_id: uuid("region_id")
     .notNull()
@@ -32,9 +32,9 @@ export const cluster = pgTable("clusters", {
   index("clusters_status_idx").on(table.status),
   index("clusters_health_status_idx").on(table.health_status),
   index("clusters_provider_idx").on(table.provider),
-]).enableRLS();
+]);
 
-export const cluster_ingress_endpoint = pgTable("cluster_ingress_endpoints", {
+export const cluster_ingress_endpoint = pgTable.withRLS("cluster_ingress_endpoints", {
   id: uuid("id").primaryKey(),
   cluster_id: uuid("cluster_id")
     .notNull()
@@ -51,9 +51,9 @@ export const cluster_ingress_endpoint = pgTable("cluster_ingress_endpoints", {
   index("cluster_ingress_endpoints_cluster_id_idx").on(table.cluster_id),
   index("cluster_ingress_endpoints_health_status_idx").on(table.health_status),
   index("cluster_ingress_endpoints_enabled_idx").on(table.enabled),
-]).enableRLS();
+]);
 
-export const cluster_join_credential = pgTable("cluster_join_credentials", {
+export const cluster_join_credential = pgTable.withRLS("cluster_join_credentials", {
   id: uuid("id").primaryKey(),
   cluster_id: uuid("cluster_id")
     .notNull()
@@ -69,4 +69,4 @@ export const cluster_join_credential = pgTable("cluster_join_credentials", {
   index("cluster_join_credentials_cluster_id_idx").on(table.cluster_id),
   index("cluster_join_credentials_expires_at_idx").on(table.expires_at),
   index("cluster_join_credentials_token_hash_idx").on(table.token_hash),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/infrastructure/durability.ts
+++ b/packages/migrations/schema/infrastructure/durability.ts
@@ -5,7 +5,7 @@ import { app_tenant } from "../rls.ts";
 export const S3_PROVIDER_TYPES = ["aws_s3", "cloudflare_r2"] as const;
 export const s3_provider_type = pgEnum("s3_provider_type", S3_PROVIDER_TYPES);
 
-export const s3_provider = pgTable("s3_providers", {
+export const s3_provider = pgTable.withRLS("s3_providers", {
   id: uuid("id").primaryKey(),
   provider_type: s3_provider_type("provider_type").notNull(),
   endpoint_url: text("endpoint_url").notNull(),
@@ -22,4 +22,4 @@ export const s3_provider = pgTable("s3_providers", {
     to: app_tenant,
     using: sql`true`,
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/infrastructure/regions.ts
+++ b/packages/migrations/schema/infrastructure/regions.ts
@@ -6,7 +6,7 @@ import { app_tenant } from "../rls.ts";
 export const region_status = pgEnum("region_status", ["active", "inactive", "maintenance"]);
 export const region_routing_mode = pgEnum("region_routing_mode", ["active", "draining", "disabled"]);
 
-export const region = pgTable("regions", {
+export const region = pgTable.withRLS("regions", {
   id: uuid("id").primaryKey(),
   slug: text("slug").notNull().unique(),
   display_name: text("display_name").notNull(),
@@ -26,4 +26,4 @@ export const region = pgTable("regions", {
     to: app_tenant,
     using: sql`true`,
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/infrastructure/registry-storage.ts
+++ b/packages/migrations/schema/infrastructure/registry-storage.ts
@@ -3,7 +3,7 @@ import { index, pgPolicy, pgTable, text, timestamp, uniqueIndex, uuid } from "dr
 import { s3_provider } from "./durability.ts";
 import { app_tenant } from "../rls.ts";
 
-export const registry_storage = pgTable("registry_storage", {
+export const registry_storage = pgTable.withRLS("registry_storage", {
   id: uuid("id").primaryKey(),
   service: text("service").notNull().default("distribution"),
   provider_id: uuid("provider_id")
@@ -26,4 +26,4 @@ export const registry_storage = pgTable("registry_storage", {
     to: app_tenant,
     using: sql`true`,
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/infrastructure/worker-jobs.ts
+++ b/packages/migrations/schema/infrastructure/worker-jobs.ts
@@ -3,7 +3,7 @@ import { check, index, integer, jsonb, pgPolicy, pgTable, text, timestamp, uniqu
 import { organization } from "../tenants/organization.ts";
 import { app_tenant } from "../rls.ts";
 
-export const worker_job = pgTable("worker_job", {
+export const worker_job = pgTable.withRLS("worker_job", {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id").references(() => organization.id, { onDelete: "cascade" }),
   queue_name: text("queue_name").notNull(),
@@ -30,9 +30,9 @@ export const worker_job = pgTable("worker_job", {
   uniqueIndex("worker_job_active_dedupe_uidx")
     .on(table.queue_name, table.dedupe_key)
     .where(sql`${table.dedupe_key} is not null and ${table.status} in ('queued', 'running')`),
-]).enableRLS();
+]);
 
-export const registry_maintenance = pgTable("registry_maintenance", {
+export const registry_maintenance = pgTable.withRLS("registry_maintenance", {
   service: text("service").primaryKey().default("distribution"),
   gc_access_key_id: text("gc_access_key_id").notNull().unique(),
   phase: text("phase").notNull().default("idle"),
@@ -52,4 +52,4 @@ export const registry_maintenance = pgTable("registry_maintenance", {
     to: app_tenant,
     using: sql`true`,
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/projects/containers.ts
+++ b/packages/migrations/schema/projects/containers.ts
@@ -5,7 +5,7 @@ import { region } from '../infrastructure/regions.ts';
 import { app_tenant, orgAllowed } from '../rls.ts';
 import { external_registry } from '../tenants/registry.ts';
 
-export const container = pgTable('container', {
+export const container = pgTable.withRLS('container', {
   id: uuid("id").primaryKey(),
   project_id: uuid("project_id")
     .notNull()
@@ -29,9 +29,9 @@ export const container = pgTable('container', {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const container_version = pgTable('container_version', {
+export const container_version = pgTable.withRLS('container_version', {
   id: uuid("id").primaryKey(),
   container_id: uuid("container_id")
     .notNull()
@@ -69,4 +69,4 @@ export const container_version = pgTable('container_version', {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/projects/index.ts
+++ b/packages/migrations/schema/projects/index.ts
@@ -6,7 +6,7 @@ export * from './containers.ts';
 export * from './postgres.ts';
 export * from './storage.ts';
 
-export const project = pgTable('project', {
+export const project = pgTable.withRLS('project', {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id")
     .notNull()
@@ -28,9 +28,9 @@ export const project = pgTable('project', {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const project_environment = pgTable('project_environment', {
+export const project_environment = pgTable.withRLS('project_environment', {
   id: uuid("id").primaryKey(),
   project_id: uuid("project_id")
     .notNull()
@@ -56,9 +56,9 @@ export const project_environment = pgTable('project_environment', {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const project_timeline = pgTable('project_timeline', {
+export const project_timeline = pgTable.withRLS('project_timeline', {
   id: uuid("id").primaryKey(),
   project_id: uuid("project_id")
     .notNull()
@@ -95,4 +95,4 @@ export const project_timeline = pgTable('project_timeline', {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/projects/postgres.ts
+++ b/packages/migrations/schema/projects/postgres.ts
@@ -3,7 +3,7 @@ import { project, project_environment } from "./index.ts"
 import { organization } from "../tenants/organization.ts";
 import { app_tenant, orgAllowed } from "../rls.ts";
 
-export const postgres_database = pgTable('postgres_database', {
+export const postgres_database = pgTable.withRLS('postgres_database', {
   id: uuid("id").primaryKey(),
   project_id: uuid("project_id")
     .notNull()
@@ -24,9 +24,9 @@ export const postgres_database = pgTable('postgres_database', {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const postgres_database_branch = pgTable('postgres_database_branch', {
+export const postgres_database_branch = pgTable.withRLS('postgres_database_branch', {
   id: uuid("id").primaryKey(),
   database_id: uuid("database_id")
     .notNull()
@@ -57,4 +57,4 @@ export const postgres_database_branch = pgTable('postgres_database_branch', {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/projects/storage.ts
+++ b/packages/migrations/schema/projects/storage.ts
@@ -7,7 +7,7 @@ import { region } from "../infrastructure/regions.ts";
 
 export const bucket_status = pgEnum("bucket_status", ["provisioning", "ready", "deleting", "failed"]);
 
-export const bucket = pgTable('bucket', {
+export const bucket = pgTable.withRLS('bucket', {
   id: uuid("id").primaryKey(),
   project_id: uuid("project_id")
     .notNull()
@@ -31,9 +31,9 @@ export const bucket = pgTable('bucket', {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const storage_access_token = pgTable("storage_access_token", {
+export const storage_access_token = pgTable.withRLS("storage_access_token", {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id")
     .notNull()
@@ -60,9 +60,9 @@ export const storage_access_token = pgTable("storage_access_token", {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const storage_access_token_bucket = pgTable("storage_access_token_bucket", {
+export const storage_access_token_bucket = pgTable.withRLS("storage_access_token_bucket", {
   access_token_id: uuid("access_token_id").notNull(),
   bucket_id: uuid("bucket_id").notNull(),
   organization_id: uuid("organization_id")
@@ -91,4 +91,4 @@ export const storage_access_token_bucket = pgTable("storage_access_token_bucket"
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/tenants/api-keys.ts
+++ b/packages/migrations/schema/tenants/api-keys.ts
@@ -3,7 +3,7 @@ import { organization } from "./organization.ts";
 import { app_tenant, orgAllowed } from "../rls.ts";
 import { API_KEY_SCOPE_VALUES } from "../../utils/api-key-scopes.ts";
 
-export const api_keys = pgTable("api_keys", {
+export const api_keys = pgTable.withRLS("api_keys", {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id")
     .notNull()
@@ -24,11 +24,11 @@ export const api_keys = pgTable("api_keys", {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
 export const api_key_scopes_type = pgEnum("api_key_scopes_type", API_KEY_SCOPE_VALUES);
 
-export const api_key_scopes = pgTable("api_key_scopes", {
+export const api_key_scopes = pgTable.withRLS("api_key_scopes", {
   id: uuid("id").primaryKey(),
   api_key_id: uuid("api_key_id").notNull(),
   organization_id: uuid("organization_id")
@@ -52,4 +52,4 @@ export const api_key_scopes = pgTable("api_key_scopes", {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/tenants/organization.ts
+++ b/packages/migrations/schema/tenants/organization.ts
@@ -11,8 +11,9 @@ import {
 import { sql } from "drizzle-orm";
 import { user } from "./studio.ts";
 import { app_tenant, orgAllowed } from "../rls.ts";
+import { MEMBER_PERMISSION_SCOPE_VALUES } from "../../utils/api-key-scopes.ts";
 
-export const organization = pgTable(
+export const organization = pgTable.withRLS(
   "organization",
   {
     id: uuid("id").primaryKey(),
@@ -51,9 +52,9 @@ export const organization = pgTable(
       withCheck: sql`true`,
     }),
   ],
-).enableRLS();
+);
 
-export const organization_member = pgTable(
+export const organization_member = pgTable.withRLS(
   "organization_member",
   {
     id: uuid("id").primaryKey(),
@@ -81,14 +82,53 @@ export const organization_member = pgTable(
       withCheck: orgAllowed(table.organization_id),
     }),
   ],
-).enableRLS();
+);
+
+export const organization_member_permission_scope_type = pgEnum(
+  "organization_member_permission_scope_type",
+  MEMBER_PERMISSION_SCOPE_VALUES,
+);
+
+export const organization_member_permission = pgTable.withRLS(
+  "organization_member_permission",
+  {
+    id: uuid("id").primaryKey(),
+    member_id: uuid("member_id")
+      .notNull()
+      .references(() => organization_member.id, { onDelete: "cascade" }),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    scope: organization_member_permission_scope_type("scope").notNull(),
+    created_at: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("organization_member_permission_member_id_scope_uidx").on(
+      table.member_id,
+      table.scope,
+    ),
+    index("organization_member_permission_organization_id_idx").on(
+      table.organization_id,
+    ),
+    index("organization_member_permission_member_id_idx").on(table.member_id),
+    pgPolicy("organization_member_permission_tenant_rls", {
+      as: "permissive",
+      for: "all",
+      to: app_tenant,
+      using: orgAllowed(table.organization_id),
+      withCheck: orgAllowed(table.organization_id),
+    }),
+  ],
+);
 
 export const organization_invitation_status = pgEnum(
   "organization_invitation_status",
   ["pending", "accepted", "declined", "revoked"],
 );
 
-export const organization_invitation = pgTable(
+export const organization_invitation = pgTable.withRLS(
   "organization_invitation",
   {
     id: uuid("id").primaryKey(),
@@ -117,9 +157,9 @@ export const organization_invitation = pgTable(
       withCheck: orgAllowed(table.organization_id),
     }),
   ],
-).enableRLS();
+);
 
-export const active_organization = pgTable("active_organization", {
+export const active_organization = pgTable.withRLS("active_organization", {
   user_id: uuid("user_id")
     .primaryKey()
     .references(() => user.id, { onDelete: "cascade" }).unique(),
@@ -135,4 +175,4 @@ export const active_organization = pgTable("active_organization", {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/schema/tenants/registry.ts
+++ b/packages/migrations/schema/tenants/registry.ts
@@ -3,7 +3,7 @@ import { sql } from "drizzle-orm";
 import { app_tenant, orgAllowed } from "../rls.ts";
 import { organization } from "./organization.ts";
 
-export const registry_repositories = pgTable("registry_repositories", {
+export const registry_repositories = pgTable.withRLS("registry_repositories", {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id")
     .notNull()
@@ -21,9 +21,9 @@ export const registry_repositories = pgTable("registry_repositories", {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const external_registry = pgTable("external_registry", {
+export const external_registry = pgTable.withRLS("external_registry", {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id")
     .notNull()
@@ -45,9 +45,9 @@ export const external_registry = pgTable("external_registry", {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const registry_access_tokens = pgTable("registry_access_tokens", {
+export const registry_access_tokens = pgTable.withRLS("registry_access_tokens", {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id")
     .notNull()
@@ -70,9 +70,9 @@ export const registry_access_tokens = pgTable("registry_access_tokens", {
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);
 
-export const registry_repository_grants = pgTable("registry_repository_grants", {
+export const registry_repository_grants = pgTable.withRLS("registry_repository_grants", {
   id: uuid("id").primaryKey(),
   organization_id: uuid("organization_id")
     .notNull()
@@ -104,4 +104,4 @@ export const registry_repository_grants = pgTable("registry_repository_grants", 
     using: orgAllowed(table.organization_id),
     withCheck: orgAllowed(table.organization_id),
   }),
-]).enableRLS();
+]);

--- a/packages/migrations/utils/api-key-scopes.ts
+++ b/packages/migrations/utils/api-key-scopes.ts
@@ -27,3 +27,25 @@ export const API_KEY_SCOPE_VALUES = [
   "registry:update",
   "registry:delete",
 ] as const;
+
+export const ORGANIZATION_MANAGEMENT_SCOPE_VALUES = [
+  "org:update",
+  "member:invite",
+  "member:remove",
+  "api-key:manage",
+] as const;
+
+// Member permissions reuse the API-key vocabulary plus org-management scopes.
+// API keys stay resource-scoped and never carry org-management scopes.
+export const MEMBER_PERMISSION_SCOPE_VALUES = [
+  ...API_KEY_SCOPE_VALUES,
+  ...ORGANIZATION_MANAGEMENT_SCOPE_VALUES,
+] as const;
+
+export type ApiKeyScope = (typeof API_KEY_SCOPE_VALUES)[number];
+export type MemberPermissionScope = (typeof MEMBER_PERMISSION_SCOPE_VALUES)[number];
+
+export const isMemberPermissionScope = (
+  value: string,
+): value is MemberPermissionScope =>
+  (MEMBER_PERMISSION_SCOPE_VALUES as readonly string[]).includes(value);

--- a/packages/migrations/utils/event-types.ts
+++ b/packages/migrations/utils/event-types.ts
@@ -3,6 +3,8 @@ export const EVENT_TYPE_VALUES = [
   "organization:updated",
   "organization:member_added",
   "organization:member_removed",
+  "organization:member_updated",
+  "organization:permissions_updated",
   "organization:invitation_created",
   "organization:invitation_accepted",
   "organization:invitation_revoked",

--- a/packages/ui/app/layouts/auth.vue
+++ b/packages/ui/app/layouts/auth.vue
@@ -18,93 +18,116 @@ const draftRevisionQuery = computed(() => {
     : ''
 })
 
-const items = computed<NavigationMenuItem[]>(() => [
-  {
-    label: 'Overview',
-    icon: ICONS.overview,
-    to: `/${store.organization?.slug}`,
-    exact: true,
-  },
-  {
-    type: "label",
-    label: 'Project Resources',
-  },
-  {
-    label: 'Containers',
-    icon: ICONS.containers,
-    to: `/${store.organization?.slug}/containers${navProjectId.value ? `/${navProjectId.value}${routeEnvironmentId.value ? `/${routeEnvironmentId.value}` : ''}` : ''}${draftRevisionQuery.value}`,
-  },
-  {
-    label: 'Databases',
-    icon: ICONS.databases,
-    open: true,
-    children: [
-      {
-        label: 'Postgres',
-        to: `/${store.organization?.slug}/databases/postgres${navProjectId.value ? `/${navProjectId.value}` : ''}`,
-      },
-    ]
-  },
-  {
-    label: 'Secrets',
-    icon: ICONS.secrets,
-    disabled: true,
-  },
-  {
-    label: "Storage",
-    icon: ICONS.storage,
-    to: `/${store.organization?.slug}/storage${navProjectId.value ? `/${navProjectId.value}` : ''}`,
-  },
-  {
-    type: "label",
-    label: 'Organization',
-  },
-  {
-    label: "Registry",
-    icon: ICONS.registry,
-    to: `/${store.organization?.slug}/registry`,
-  },
-  {
-    label: 'Logs',
-    icon: ICONS.logs,
-    disabled: true,
-    to: `/${store.organization?.slug}/logs`,
-  },
-  {
-    label: 'Analytics',
-    icon: ICONS.analytics,
-    disabled: true,
-    to: `/${store.organization?.slug}/analytics`,
-  },
-  {
-    type: "label",
-    label: 'Settings',
-  },
-      {
-        label: 'General',
-        icon: ICONS.general,
-        to: `/${store.organization?.slug}/settings`,
-        exact: true,
-      },
-      {
-        label: 'Members',
-        icon: ICONS.members,
-        to: `/${store.organization?.slug}/settings/members`,
-        exact: true,
-      },
-      {
-        label: 'Authentication',
-        icon: ICONS.authentication,
-        to: `/${store.organization?.slug}/settings/authentication`,
-        exact: true,
-      },
-      {
-        label: 'Audit Log',
-        icon: ICONS.logs,
-        to: `/${store.organization?.slug}/settings/audit-log`,
-        exact: true,
-      },
-] satisfies NavigationMenuItem[]);
+const items = computed<NavigationMenuItem[]>(() => {
+  const all: NavigationMenuItem[] = [
+    {
+      label: 'Overview',
+      icon: ICONS.overview,
+      to: `/${store.organization?.slug}`,
+      exact: true,
+    },
+    {
+      type: "label",
+      label: 'Project Resources',
+    },
+    {
+      label: 'Containers',
+      icon: ICONS.containers,
+      to: `/${store.organization?.slug}/containers${navProjectId.value ? `/${navProjectId.value}${routeEnvironmentId.value ? `/${routeEnvironmentId.value}` : ''}` : ''}${draftRevisionQuery.value}`,
+    },
+    {
+      label: 'Databases',
+      icon: ICONS.databases,
+      open: true,
+      children: [
+        {
+          label: 'Postgres',
+          to: `/${store.organization?.slug}/databases/postgres${navProjectId.value ? `/${navProjectId.value}` : ''}`,
+        },
+      ]
+    },
+    {
+      label: 'Secrets',
+      icon: ICONS.secrets,
+      disabled: true,
+    },
+    {
+      label: "Storage",
+      icon: ICONS.storage,
+      to: `/${store.organization?.slug}/storage${navProjectId.value ? `/${navProjectId.value}` : ''}`,
+    },
+    {
+      type: "label",
+      label: 'Organization',
+    },
+    {
+      label: "Registry",
+      icon: ICONS.registry,
+      to: `/${store.organization?.slug}/registry`,
+    },
+    {
+      label: 'Logs',
+      icon: ICONS.logs,
+      disabled: true,
+      to: `/${store.organization?.slug}/logs`,
+    },
+    {
+      label: 'Analytics',
+      icon: ICONS.analytics,
+      disabled: true,
+      to: `/${store.organization?.slug}/analytics`,
+    },
+    {
+      type: "label",
+      label: 'Settings',
+    },
+        {
+          label: 'General',
+          icon: ICONS.general,
+          to: `/${store.organization?.slug}/settings`,
+          exact: true,
+        },
+        {
+          label: 'Members',
+          icon: ICONS.members,
+          to: `/${store.organization?.slug}/settings/members`,
+          exact: true,
+        },
+        {
+          label: 'Authentication',
+          icon: ICONS.authentication,
+          to: `/${store.organization?.slug}/settings/authentication`,
+          exact: true,
+        },
+        {
+          label: 'Audit Log',
+          icon: ICONS.logs,
+          to: `/${store.organization?.slug}/settings/audit-log`,
+          exact: true,
+        },
+  ];
+
+  // Hide nav entries the active member has no scope for; the backend stays the boundary.
+  const requiredScope: Record<string, string> = {
+    Containers: 'container:read',
+    Databases: 'database:postgres:read',
+    Storage: 'bucket:read',
+    Registry: 'registry:read',
+    General: 'org:update',
+    Authentication: 'api-key:manage',
+    'Audit Log': 'event:read',
+  };
+
+  return all.filter((item) => {
+    const label = item.label as string;
+    if (label === 'Members') {
+      return store.isOwner || store.can('member:invite') || store.can('member:remove');
+    }
+    const scope = label ? requiredScope[label] : undefined;
+    if (!scope) return true;
+    return store.can(scope);
+  });
+});
 </script>
 
 <template>

--- a/packages/ui/app/pages/[organization_slug]/settings/members.vue
+++ b/packages/ui/app/pages/[organization_slug]/settings/members.vue
@@ -3,6 +3,7 @@ import { h } from 'vue';
 import type { TableColumn, TableRow } from '@nuxt/ui';
 import * as z from 'zod';
 import { ICONS } from '~/utils/icons'
+import { MEMBER_PERMISSION_SCOPE_VALUES } from '@cplane/migrations/utils'
 
 const store = useStore();
 
@@ -34,6 +35,10 @@ const isAdding = ref(false);
 const deleteModalOpen = ref(false);
 const isRemoving = ref(false);
 const selectedMemberToDelete = ref<Member | null>(null);
+const permissionsModalOpen = ref(false);
+const isSavingPermissions = ref(false);
+const selectedMemberForPermissions = ref<Member | null>(null);
+const permissionsDraft = ref<Record<string, boolean>>({});
 
 const members = computed(() => data.value?.data ?? []);
 const total = computed(() => data.value?.pagination.total ?? 0);
@@ -70,20 +75,78 @@ const columns: TableColumn<Member>[] = [
   },
 ];
 
-const getContextMenuItems = (row: TableRow<Member>) => [
-  {
-    type: 'label' as const,
-    label: 'Actions',
-  },
-  {
-    label: 'Remove Member',
-    color: 'error' as const,
-    onSelect: () => {
-      selectedMemberToDelete.value = row.original;
-      deleteModalOpen.value = true;
+const getContextMenuItems = (row: TableRow<Member>) => {
+  const items: Array<Record<string, unknown>> = [
+    {
+      type: 'label' as const,
+      label: 'Actions',
     },
-  },
-];
+  ];
+  if (store.isOwner && row.original.role !== 'owner') {
+    items.push({
+      label: 'Edit Permissions',
+      onSelect: () => {
+        selectedMemberForPermissions.value = row.original;
+        permissionsDraft.value = Object.fromEntries(
+          MEMBER_PERMISSION_SCOPE_VALUES.map((scope) => [
+            scope,
+            row.original.permissions.includes(scope),
+          ]),
+        );
+        permissionsModalOpen.value = true;
+      },
+    });
+  }
+  if (row.original.role !== 'owner') {
+    items.push({
+      label: 'Remove Member',
+      color: 'error' as const,
+      onSelect: () => {
+        selectedMemberToDelete.value = row.original;
+        deleteModalOpen.value = true;
+      },
+    });
+  }
+  return items;
+};
+
+const onSavePermissions = async () => {
+  isSavingPermissions.value = true;
+  try {
+    if (!selectedMemberForPermissions.value) return;
+
+    await $fetch(
+      `/api/organization/${store.organization?.id as ':organization_id'}/members/${selectedMemberForPermissions.value.id as ':member_id'}/permissions`,
+      {
+        method: 'PUT',
+        body: {
+          permissions: Object.entries(permissionsDraft.value)
+            .filter(([, enabled]) => enabled)
+            .map(([scope]) => scope),
+        },
+      }
+    );
+
+    toast.add({
+      title: 'Success',
+      description: 'Permissions updated successfully',
+      color: 'success',
+    });
+
+    permissionsModalOpen.value = false;
+    selectedMemberForPermissions.value = null;
+    refresh();
+  } catch (error) {
+    toast.add({
+      title: 'An Error accured',
+      description:
+        error instanceof Error ? error.message : 'Failed to update permissions',
+      color: 'error' as const,
+    });
+  } finally {
+    isSavingPermissions.value = false;
+  }
+};
 
 const onDeleteMember = async () => {
   isRemoving.value = true;
@@ -213,6 +276,27 @@ const onAddMember = async () => {
             <UButton variant="ghost" color="neutral" @click="deleteModalOpen = false">Cancel</UButton>
             <UButton :icon="ICONS.trash" color="error" :loading="isRemoving" @click="onDeleteMember">Remove</UButton>
           </div>
+        </div>
+      </template>
+    </UModal>
+
+    <UModal
+      v-model:open="permissionsModalOpen"
+      :title="`Permissions — ${selectedMemberForPermissions?.user.name ?? ''}`"
+      description="Scopes mirror the API-key vocabulary and gate this member's access"
+    >
+      <template #body>
+        <div class="max-h-96 space-y-1 overflow-y-auto pr-1">
+          <UCheckbox
+            v-for="scope in MEMBER_PERMISSION_SCOPE_VALUES"
+            :key="scope"
+            v-model="permissionsDraft[scope]"
+            :label="scope"
+          />
+        </div>
+        <div class="mt-4 flex justify-end gap-3">
+          <UButton variant="ghost" color="neutral" @click="permissionsModalOpen = false">Cancel</UButton>
+          <UButton color="primary" :loading="isSavingPermissions" @click="onSavePermissions">Save</UButton>
         </div>
       </template>
     </UModal>

--- a/packages/ui/app/stores/store.ts
+++ b/packages/ui/app/stores/store.ts
@@ -29,6 +29,16 @@ export const useStore = defineStore("auth", {
     environments_project_id: null,
     refreshKey: 0,
   }),
+  getters: {
+    can(): (scope: string) => boolean {
+      return (scope) =>
+        this.organization?.member.role === "owner" ||
+        (this.organization?.member.permissions?.includes(scope) ?? false)
+    },
+    isOwner(): boolean {
+      return this.organization?.member.role === "owner"
+    },
+  },
 
   actions: {
     setOrganization(organization: Organization | null) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,8 @@
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
     "typecheck": "nuxt typecheck",
-    "lint:fix": "eslint --fix ."
+    "lint:fix": "eslint --fix .",
+    "test": "vitest run"
   },
   "dependencies": {
     "@better-auth/passkey": "^1.6.23",
@@ -42,6 +43,7 @@
     "@nuxt/eslint": "1.15.2",
     "drizzle-kit": "1.0.0-rc.4",
     "eslint": "^10.7.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/ui/server/api/organization/[organization_id]/api-keys/[api_key_id]/index.delete.ts
+++ b/packages/ui/server/api/organization/[organization_id]/api-keys/[api_key_id]/index.delete.ts
@@ -7,7 +7,7 @@ export default defineEventHandler(async (event) => {
   const organization_id = params.organization_id as string;
   const api_key_id = params.api_key_id as string;
 
-  await getOrganizationMembership(event, organization_id);
+  await requireScope(event, "api-key:manage", organization_id);
   const deleted = await withTenantDb([organization_id], async (tx) => {
     const [deleted] = await tx
       .delete(api_keys)

--- a/packages/ui/server/api/organization/[organization_id]/api-keys/[api_key_id]/index.get.ts
+++ b/packages/ui/server/api/organization/[organization_id]/api-keys/[api_key_id]/index.get.ts
@@ -1,14 +1,14 @@
 import { withTenantDb } from "~~/server/utils/db";
 import { api_keys, api_key_scopes } from "~~/server/schema";
 import { eq, and } from "drizzle-orm";
-import { getOrganizationMembership } from "~~/server/utils/authorization";
+import { requireScope } from "~~/server/utils/authorization";
 
 export default defineEventHandler(async (event) => {
   const params = getRouterParams(event);
   const organization_id = params.organization_id as string;
   const api_key_id = params.api_key_id as string;
 
-  await getOrganizationMembership(event, organization_id);
+  await requireScope(event, "api-key:manage", organization_id);
   const { key, scopes } = await withTenantDb([organization_id], async (tx) => {
     const result = await tx
       .select()

--- a/packages/ui/server/api/organization/[organization_id]/api-keys/[api_key_id]/index.put.ts
+++ b/packages/ui/server/api/organization/[organization_id]/api-keys/[api_key_id]/index.put.ts
@@ -2,7 +2,7 @@ import { withTenantDb } from "~~/server/utils/db";
 import type { api_key_scopes_type } from "~~/server/schema";
 import { api_keys, api_key_scopes } from "~~/server/schema";
 import { eq, and, notInArray } from "drizzle-orm";
-import { getOrganizationMembership } from "~~/server/utils/authorization";
+import { requireScope } from "~~/server/utils/authorization";
 import { uuidv7 } from "uuidv7";
 import { API_KEY_SCOPE_VALUES } from "@cplane/migrations/utils";
 
@@ -11,7 +11,7 @@ export default defineEventHandler(async (event) => {
   const organization_id = params.organization_id as string;
   const api_key_id = params.api_key_id as string;
 
-  await getOrganizationMembership(event, organization_id);
+  await requireScope(event, "api-key:manage", organization_id);
 
   const body = await readBody(event);
   const { name, scopes, allowed_ips } = body as { name: string; scopes: Record<string, boolean>; allowed_ips?: string | null };

--- a/packages/ui/server/api/organization/[organization_id]/api-keys/index.get.ts
+++ b/packages/ui/server/api/organization/[organization_id]/api-keys/index.get.ts
@@ -1,13 +1,13 @@
 import { withTenantDb } from "~~/server/utils/db";
 import { api_keys } from "~~/server/schema";
 import { eq } from "drizzle-orm";
-import { getOrganizationMembership } from "~~/server/utils/authorization";
+import { requireScope } from "~~/server/utils/authorization";
 
 export default defineEventHandler(async (event) => {
   const params = getRouterParams(event);
   const organization_id = params.organization_id as string;
 
-  await getOrganizationMembership(event, organization_id);
+  await requireScope(event, "api-key:manage", organization_id);
 
   const query = getQuery(event);
   const limit = Math.min(parseInt(query.limit as string) || 50, 100);

--- a/packages/ui/server/api/organization/[organization_id]/api-keys/index.post.ts
+++ b/packages/ui/server/api/organization/[organization_id]/api-keys/index.post.ts
@@ -5,7 +5,7 @@ import { withTenantDb } from "~~/server/utils/db";
 import { API_KEY_SCOPE_VALUES } from "@cplane/migrations/utils";
 
 export default defineEventHandler(async (event) => {
-  const membership = await getOrganizationMembership(event);
+  const membership = await requireScope(event, "api-key:manage");
 
   const body = await readBody(event);
   const { name, scopes, expires_at, allowed_ips } = body as { name: string; scopes: Record<string, boolean>; expires_at?: number | null; allowed_ips?: string | null };

--- a/packages/ui/server/api/organization/[organization_id]/index.delete.ts
+++ b/packages/ui/server/api/organization/[organization_id]/index.delete.ts
@@ -1,17 +1,23 @@
 import { organization } from "~~/server/schema";
 import { eq } from "drizzle-orm";
 import { withTenantDb } from "~~/server/utils/db";
+import { requireOwner, assertAllowed } from "~~/server/utils/authorization";
+import { denyDeleteOrganization } from "~~/server/utils/permissions";
 
 export default defineEventHandler(async (event) => {
-  const membership = await getOrganizationMembership(event);
+  const membership = await requireOwner(event);
 
-  const organizationId = membership.organization_id;
-  if (!organizationId) {
+  const body = await readBody<{ confirm?: boolean }>(event).catch(() => ({ confirm: false }));
+  if (body.confirm !== true) {
     throw createError({
       statusCode: 400,
-      statusMessage: "Organization ID is required",
+      statusMessage: "Confirmation required: pass { \"confirm\": true } to delete this organization",
     });
   }
+
+  assertAllowed(denyDeleteOrganization(membership));
+
+  const organizationId = membership.organization_id;
 
   await withTenantDb([organizationId], async (tx) => {
     const rows = await tx

--- a/packages/ui/server/api/organization/[organization_id]/index.get.ts
+++ b/packages/ui/server/api/organization/[organization_id]/index.get.ts
@@ -2,6 +2,7 @@ import { organization, organization_member } from "~~/server/schema";
 import { withTenantDb } from "~~/server/utils/db";
 import { eq, and } from "drizzle-orm";
 import type { Project } from '@cplane/sdk';
+import { permissionsForUser } from "~~/server/utils/authorization";
 
 export default defineEventHandler(async (event) => {
   const membership = await getOrganizationMembership(event);
@@ -39,20 +40,26 @@ export default defineEventHandler(async (event) => {
     });
   }
 
+  const org = _organization[0]!;
+
   let projects: Project[] = [];
   try {
     const backendUrl = process.env.BACKEND_URL || 'http://localhost:8080';
     const headers = getRequestHeaders(event);
-    const response = await $fetch(`${backendUrl}/api/organization/${organizationId}/projects`, {
+    const response = await $fetch<{ data?: Project[] }>(`${backendUrl}/api/organization/${organizationId}/projects`, {
       headers: headers as Record<string, string>,
     });
-    projects = (response as any)?.data ?? [];
+    projects = response?.data ?? [];
   } catch {
     projects = [];
   }
 
   return {
-    ..._organization[0],
+    ...org,
+    member: {
+      ...org.member,
+      permissions: await permissionsForUser(organizationId, membership.user_id),
+    },
     projects,
   };
 });

--- a/packages/ui/server/api/organization/[organization_id]/invitations/[invitation_id]/index.delete.ts
+++ b/packages/ui/server/api/organization/[organization_id]/invitations/[invitation_id]/index.delete.ts
@@ -1,6 +1,8 @@
 import { organization_invitation } from "~~/server/schema";
 import { withTenantDb } from "~~/server/utils/db";
 import { eq, and } from "drizzle-orm";
+import { getOrganizationMembership, assertAllowed } from "~~/server/utils/authorization";
+import { denyRevokeInvitation } from "~~/server/utils/permissions";
 
 export default defineEventHandler(async (event) => {
   const params = getRouterParams(event);
@@ -21,6 +23,8 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Organization mismatch",
     });
   }
+
+  assertAllowed(denyRevokeInvitation(membership));
 
   await withTenantDb([organizationId], async (tx) => {
     const updated = await tx

--- a/packages/ui/server/api/organization/[organization_id]/invitations/index.post.ts
+++ b/packages/ui/server/api/organization/[organization_id]/invitations/index.post.ts
@@ -3,16 +3,18 @@ import { withTenantDb } from "~~/server/utils/db";
 import { and, eq } from "drizzle-orm";
 import { uuidv7 } from "uuidv7";
 import { logEvent } from "~~/server/utils/events";
+import { getOrganizationMembership, assertAllowed } from "~~/server/utils/authorization";
+import { denyCreateInvitation } from "~~/server/utils/permissions";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody<{
     email: string;
-    role: "member" | "admin";
+    role?: string;
     organization_id: string;
   }>(event);
 
-  const { email, role, organization_id } = body;
-  const inviteEmail = email.trim().toLowerCase();
+  const { email, organization_id } = body;
+  const inviteEmail = email?.trim().toLowerCase();
 
   if (!email || !inviteEmail) {
     throw createError({
@@ -35,6 +37,9 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Organization mismatch",
     });
   }
+
+  assertAllowed(denyCreateInvitation(membership, body.role ?? "member"));
+  const role = (body.role ?? "member") as "owner" | "member";
 
   const invitationId = uuidv7();
   const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days

--- a/packages/ui/server/api/organization/[organization_id]/members/[member_id].delete.ts
+++ b/packages/ui/server/api/organization/[organization_id]/members/[member_id].delete.ts
@@ -1,6 +1,8 @@
 import { organization_member } from "~~/server/schema";
 import { withTenantDb } from "~~/server/utils/db";
-import { eq, and } from "drizzle-orm";
+import { eq, and, count } from "drizzle-orm";
+import { getOrganizationMembership, assertAllowed } from "~~/server/utils/authorization";
+import { denyRemoveMember } from "~~/server/utils/permissions";
 
 export default defineEventHandler(async (event) => {
   const membership = await getOrganizationMembership(event);
@@ -14,14 +16,37 @@ export default defineEventHandler(async (event) => {
   }
 
   const deletedMember = await withTenantDb([membership.organization_id], async (tx) => {
-    const [deletedMember] = await tx
-      .delete(organization_member)
+    const [target] = await tx
+      .select()
+      .from(organization_member)
       .where(
         and(
           eq(organization_member.id, member_id),
           eq(organization_member.organization_id, membership.organization_id)
         )
       )
+      .limit(1);
+
+    if (!target) {
+      return null;
+    }
+
+    const ownerRows = await tx
+      .select({ value: count() })
+      .from(organization_member)
+      .where(and(
+        eq(organization_member.organization_id, membership.organization_id),
+        eq(organization_member.role, "owner"),
+      ));
+
+    assertAllowed(denyRemoveMember(membership, target, {
+      isSelf: target.user_id === membership.user_id,
+      ownerCount: Number(ownerRows[0]?.value ?? 0),
+    }));
+
+    const [deletedMember] = await tx
+      .delete(organization_member)
+      .where(eq(organization_member.id, target.id))
       .returning();
 
     if (deletedMember) {

--- a/packages/ui/server/api/organization/[organization_id]/members/[member_id]/index.patch.ts
+++ b/packages/ui/server/api/organization/[organization_id]/members/[member_id]/index.patch.ts
@@ -1,0 +1,88 @@
+import { organization_member } from "~~/server/schema";
+import { withTenantDb, getIdentityDb } from "~~/server/utils/db";
+import { and, eq, count } from "drizzle-orm";
+import { logEvent } from "~~/server/utils/events";
+import {
+  getOrganizationMembership,
+  assertAllowed,
+  withPermissions,
+} from "~~/server/utils/authorization";
+import { denyUpdateMemberRole } from "~~/server/utils/permissions";
+
+export default defineEventHandler(async (event) => {
+  const params = getRouterParams(event);
+  const organization_id = params.organization_id as string;
+  const member_id = params.member_id as string;
+
+  if (!member_id) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Member ID is required",
+    });
+  }
+
+  const actor = await getOrganizationMembership(event, organization_id);
+
+  const body = await readBody<{ role?: unknown }>(event);
+
+  const [target] = await getIdentityDb()
+    .select({
+      id: organization_member.id,
+      role: organization_member.role,
+      organization_id: organization_member.organization_id,
+    })
+    .from(organization_member)
+    .where(eq(organization_member.id, member_id))
+    .limit(1);
+
+  if (!target || target.organization_id !== organization_id) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Member not found",
+    });
+  }
+
+  return withTenantDb([organization_id], async (tx) => {
+    const ownerRows = await tx
+      .select({ value: count() })
+      .from(organization_member)
+      .where(and(
+        eq(organization_member.organization_id, organization_id),
+        eq(organization_member.role, "owner"),
+      ));
+
+    const isSelf = actor.id === target.id;
+    const ownerCount = Number(ownerRows[0]?.value ?? 0);
+    assertAllowed(denyUpdateMemberRole(actor, body?.role, target, {
+      isSelf,
+      ownerCount,
+    }));
+
+    const role = body.role as string;
+    const [updated] = await tx
+      .update(organization_member)
+      .set({ role })
+      .where(eq(organization_member.id, target.id))
+      .returning();
+
+    if (updated) {
+      await logEvent(organization_id, "organization:member_updated", {
+        id: updated.id,
+        organization_id,
+        user_id: updated.user_id,
+        role: updated.role,
+        previous_role: target.role,
+      }, false, {}, tx);
+    }
+
+    return updated;
+  }).then(async (updated) => {
+    if (!updated) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: "Member not found",
+      });
+    }
+    return withPermissions(updated);
+  });
+});

--- a/packages/ui/server/api/organization/[organization_id]/members/[member_id]/permissions/index.put.ts
+++ b/packages/ui/server/api/organization/[organization_id]/members/[member_id]/permissions/index.put.ts
@@ -1,0 +1,91 @@
+import { organization_member, organization_member_permission } from "~~/server/schema";
+import { withTenantDb, getIdentityDb } from "~~/server/utils/db";
+import { eq } from "drizzle-orm";
+import { uuidv7 } from "uuidv7";
+import { logEvent } from "~~/server/utils/events";
+import {
+  getOrganizationMembership,
+  assertAllowed,
+  withPermissions,
+} from "~~/server/utils/authorization";
+import { denyAssignPermissions } from "~~/server/utils/permissions";
+import { isMemberPermissionScope } from "@cplane/migrations/utils";
+
+export default defineEventHandler(async (event) => {
+  const params = getRouterParams(event);
+  const organization_id = params.organization_id as string;
+  const member_id = params.member_id as string;
+
+  if (!member_id) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Member ID is required",
+    });
+  }
+
+  const actor = await getOrganizationMembership(event, organization_id);
+
+  const body = await readBody<{ permissions?: unknown }>(event);
+  const requested = body?.permissions;
+
+  if (!Array.isArray(requested) || requested.some((s) => typeof s !== "string")) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Permissions must be an array of scope strings",
+    });
+  }
+
+  const permissions = [...new Set(requested as string[])];
+  const invalid = permissions.find((scope) => !isMemberPermissionScope(scope));
+  if (invalid) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Unknown permission: ${invalid}`,
+    });
+  }
+
+  const [target] = await getIdentityDb()
+    .select({
+      id: organization_member.id,
+      role: organization_member.role,
+      organization_id: organization_member.organization_id,
+    })
+    .from(organization_member)
+    .where(eq(organization_member.id, member_id))
+    .limit(1);
+
+  if (!target || target.organization_id !== organization_id) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Member not found",
+    });
+  }
+
+  assertAllowed(denyAssignPermissions(actor, target));
+
+  await withTenantDb([organization_id], async (tx) => {
+    await tx
+      .delete(organization_member_permission)
+      .where(eq(organization_member_permission.member_id, member_id));
+
+    if (permissions.length > 0) {
+      await tx.insert(organization_member_permission).values(
+        permissions.map((scope) => ({
+          id: uuidv7(),
+          member_id,
+          organization_id,
+          scope: scope as (typeof organization_member_permission.$inferInsert)["scope"],
+        })),
+      );
+    }
+
+    await logEvent(organization_id, "organization:permissions_updated", {
+      id: target.id,
+      organization_id,
+      user_id: target.id,
+      permissions,
+    }, false, {}, tx);
+  });
+
+  return withPermissions({ id: member_id, role: target.role, permissions });
+});

--- a/packages/ui/server/api/organization/[organization_id]/members/index.get.ts
+++ b/packages/ui/server/api/organization/[organization_id]/members/index.get.ts
@@ -1,6 +1,6 @@
-import { organization_member, user } from "~~/server/schema";
+import { organization_member, user, organization_member_permission } from "~~/server/schema";
 import { withTenantDb } from "~~/server/utils/db";
-import { eq, and, or, ilike, count, ne } from "drizzle-orm";
+import { eq, and, or, ilike, count, ne, inArray } from "drizzle-orm";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -74,8 +74,29 @@ export default defineEventHandler(async (event) => {
     const totalResult = await countQuery;
     const total = totalResult[0]?.count || 0;
 
+    const memberIds = members.map((m) => m.id);
+    const permissionRows = memberIds.length
+      ? await tx
+          .select({
+            member_id: organization_member_permission.member_id,
+            scope: organization_member_permission.scope,
+          })
+          .from(organization_member_permission)
+          .where(inArray(organization_member_permission.member_id, memberIds))
+      : [];
+    const permissionsByMember = new Map<string, string[]>();
+    for (const row of permissionRows) {
+      const list = permissionsByMember.get(row.member_id) ?? [];
+      list.push(row.scope);
+      permissionsByMember.set(row.member_id, list);
+    }
+
     return {
-      data: members,
+      data: members.map((m) => ({
+        ...m,
+        role: m.role === "owner" ? "owner" : "member",
+        permissions: permissionsByMember.get(m.id) ?? [],
+      })),
       pagination: {
         total,
         limit,

--- a/packages/ui/server/api/organization/[organization_id]/members/index.post.ts
+++ b/packages/ui/server/api/organization/[organization_id]/members/index.post.ts
@@ -2,6 +2,8 @@ import { organization_member, user } from "~~/server/schema";
 import { withTenantDb } from "~~/server/utils/db";
 import { eq } from "drizzle-orm";
 import { uuidv7 } from "uuidv7";
+import { getOrganizationMembership, assertAllowed } from "~~/server/utils/authorization";
+import { denyAddMember } from "~~/server/utils/permissions";
 
 export default defineEventHandler(async (event) => {
   const membership = await getOrganizationMembership(event);
@@ -13,6 +15,8 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'Email is required',
     });
   }
+
+  assertAllowed(denyAddMember(membership));
 
   const result = await withTenantDb([membership.organization_id], async (tx) => {
     const [existingUser] = await tx

--- a/packages/ui/server/api/organization/[organization_id]/membership/index.delete.ts
+++ b/packages/ui/server/api/organization/[organization_id]/membership/index.delete.ts
@@ -28,10 +28,10 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  if (currentMembership.role === "owner" || currentMembership.role === "admin") {
+  if (currentMembership.role === "owner") {
     throw createError({
       statusCode: 403,
-      statusMessage: "Admins and owners cannot leave from this action",
+      statusMessage: "Owners cannot leave; transfer ownership first",
     });
   }
 

--- a/packages/ui/server/api/organization/[organization_id]/name.put.ts
+++ b/packages/ui/server/api/organization/[organization_id]/name.put.ts
@@ -2,6 +2,8 @@ import { withTenantDb } from "~~/server/utils/db";
 import { organization, organization_member } from "~~/server/schema";
 import { eq, and } from "drizzle-orm";
 import { logEvent } from "~~/server/utils/events";
+import { getOrganizationMembership, assertAllowed } from "~~/server/utils/authorization";
+import { denyRenameOrganization } from "~~/server/utils/permissions";
 import z from "zod";
 
 const renameOrganizationSchema = z.object({
@@ -20,6 +22,8 @@ export default defineEventHandler(async (event) => {
     });
   }
   const { name } = parsed.data;
+
+  assertAllowed(denyRenameOrganization(membership));
 
   const organizationId = membership.organization_id;
 
@@ -72,5 +76,12 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  return _organization[0];
+  const org = _organization[0]!;
+  return {
+    ...org,
+    member: {
+      ...org.member,
+      permissions: membership.permissions,
+    },
+  };
 });

--- a/packages/ui/server/api/organization/active.get.ts
+++ b/packages/ui/server/api/organization/active.get.ts
@@ -2,6 +2,7 @@
 import { active_organization, organization, organization_member } from "~~/server/schema";
 import { and, eq } from "drizzle-orm";
 import { getIdentityDb } from "~~/server/utils/db";
+import { permissionsForUser } from "~~/server/utils/authorization";
 
 export default defineEventHandler(async (event) => {
   const session = await requireSession(event);
@@ -31,6 +32,13 @@ export default defineEventHandler(async (event) => {
       statusMessage: "No active organization found for the user",
     });
   }
-  
-  return activeOrganization[0];
+
+  const row = activeOrganization[0]!;
+  return {
+    ...row,
+    member: {
+      ...row.member,
+      permissions: await permissionsForUser(row.id, session.user.id),
+    },
+  };
 });

--- a/packages/ui/server/api/organization/index.post.ts
+++ b/packages/ui/server/api/organization/index.post.ts
@@ -112,6 +112,7 @@ export default defineEventHandler(async (event) => {
     member: {
       id: session.user.id,
       role: "owner",
+      permissions: [],
     },
   };
 });

--- a/packages/ui/server/utils/authorization.ts
+++ b/packages/ui/server/utils/authorization.ts
@@ -1,8 +1,9 @@
 import { auth } from "./auth";
 import { getIdentityDb } from "./db";
-import { organization_member, user  } from "~~/server/schema";
+import { organization_member, user, organization_member_permission } from "~~/server/schema";
 import { eq, and } from "drizzle-orm";
 import type { H3Event } from "h3";
+import { hasScope, type Subject } from "./permissions";
 
 export const requireSession = async (event: H3Event) => {
   const session = await auth.api.getSession({
@@ -72,5 +73,67 @@ export async function getOrganizationMembership(event: H3Event, organization_id?
     });
   }
 
-  return userMembership
+  const membership =
+    userMembership.role === "owner"
+      ? userMembership
+      : { ...userMembership, role: "member" };
+
+  return withPermissions(membership)
+}
+
+export async function withPermissions<M extends { id: string; role: string }>(
+  membership: M,
+): Promise<M & Subject> {
+  const rows = await getIdentityDb()
+    .select({ scope: organization_member_permission.scope })
+    .from(organization_member_permission)
+    .where(eq(organization_member_permission.member_id, membership.id));
+
+  return { ...membership, permissions: rows.map((row) => row.scope) };
+}
+
+export async function permissionsForUser(
+  organization_id: string,
+  user_id: string,
+): Promise<string[]> {
+  const rows = await getIdentityDb()
+    .select({ scope: organization_member_permission.scope })
+    .from(organization_member_permission)
+    .innerJoin(
+      organization_member,
+      eq(organization_member_permission.member_id, organization_member.id),
+    )
+    .where(
+      and(
+        eq(organization_member.organization_id, organization_id),
+        eq(organization_member.user_id, user_id),
+      ),
+    );
+  return rows.map((row) => row.scope);
+}
+
+export function assertAllowed(denial: string | null) {
+  if (denial) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: denial,
+    });
+  }
+}
+
+export async function requireScope(event: H3Event, scope: string, organization_id?: string) {
+  const membership = await getOrganizationMembership(event, organization_id);
+  assertAllowed(hasScope(membership, scope) ? null : `Missing required permission: ${scope}`);
+  return membership;
+}
+
+export async function requireOwner(event: H3Event, organization_id?: string) {
+  const membership = await getOrganizationMembership(event, organization_id);
+  if (membership.role !== "owner") {
+    throw createError({
+      statusCode: 403,
+      statusMessage: "Only organization owners can perform this action",
+    });
+  }
+  return membership;
 }

--- a/packages/ui/server/utils/permissions.ts
+++ b/packages/ui/server/utils/permissions.ts
@@ -1,0 +1,118 @@
+// Pure authorization decisions for organization management.
+// Every function returns null when the action is allowed, or a reason string.
+// Kept free of Nuxt/h3 imports so it can be unit-tested directly.
+
+export const ROLES = ["owner", "member"] as const;
+export type Role = (typeof ROLES)[number];
+
+export const INVITATION_ROLES = ROLES;
+
+export type Subject = {
+  role: string;
+  permissions: readonly string[];
+};
+
+export const isOwner = (subject: Subject) => subject.role === "owner";
+
+export const hasScope = (subject: Subject, scope: string) =>
+  isOwner(subject) || subject.permissions.includes(scope);
+
+const forbidden = (reason: string) => reason;
+
+export function denyDeleteOrganization(actor: Subject): string | null {
+  if (!isOwner(actor)) {
+    return forbidden("Only organization owners can delete the organization");
+  }
+  return null;
+}
+
+export function denyRenameOrganization(actor: Subject): string | null {
+  if (!hasScope(actor, "org:update")) {
+    return forbidden("Missing required permission: org:update");
+  }
+  return null;
+}
+
+export function denyCreateInvitation(
+  actor: Subject,
+  invitedRole: unknown,
+): string | null {
+  if (!INVITATION_ROLES.includes(invitedRole as Role)) {
+    return forbidden("Role must be either owner or member");
+  }
+  if (!hasScope(actor, "member:invite")) {
+    return forbidden("Missing required permission: member:invite");
+  }
+  if (invitedRole === "owner" && !isOwner(actor)) {
+    return forbidden("Only owners can create owner invitations");
+  }
+  return null;
+}
+
+export function denyRevokeInvitation(actor: Subject): string | null {
+  if (!hasScope(actor, "member:invite")) {
+    return forbidden("Missing required permission: member:invite");
+  }
+  return null;
+}
+
+export function denyAddMember(actor: Subject): string | null {
+  if (!hasScope(actor, "member:invite")) {
+    return forbidden("Missing required permission: member:invite");
+  }
+  return null;
+}
+
+export function denyRemoveMember(
+  actor: Subject,
+  target: { role: string },
+  options: { isSelf: boolean; ownerCount: number },
+): string | null {
+  if (options.isSelf) {
+    return forbidden("Use the leave organization action to remove yourself");
+  }
+  if (target.role === "owner") {
+    if (!isOwner(actor)) {
+      return forbidden("Only owners can remove an owner");
+    }
+    if (options.ownerCount <= 1) {
+      return forbidden("Cannot remove the last owner of the organization");
+    }
+    return null;
+  }
+  if (!hasScope(actor, "member:remove")) {
+    return forbidden("Missing required permission: member:remove");
+  }
+  return null;
+}
+
+export function denyUpdateMemberRole(
+  actor: Subject,
+  nextRole: unknown,
+  target: { role: string },
+  options: { isSelf: boolean; ownerCount: number },
+): string | null {
+  if (!isOwner(actor)) {
+    return forbidden("Only owners can change member roles");
+  }
+  if (!ROLES.includes(nextRole as Role)) {
+    return forbidden("Role must be either owner or member");
+  }
+  if (options.isSelf && target.role === "owner" && nextRole !== "owner" && options.ownerCount <= 1) {
+    return forbidden("Cannot demote the last owner of the organization");
+  }
+  return null;
+}
+
+export function denyAssignPermissions(
+  actor: Subject,
+  target: { role: string },
+): string | null {
+  if (!isOwner(actor)) {
+    return forbidden("Only owners can manage member permissions");
+  }
+  if (target.role === "owner") {
+    return forbidden("Owners have full access; permissions apply to members only");
+  }
+  return null;
+}

--- a/packages/ui/shared/types/organization.ts
+++ b/packages/ui/shared/types/organization.ts
@@ -7,5 +7,6 @@ export type Organization = {
   member: {
     id: string;
     role: string;
+    permissions: string[];
   };
 }

--- a/packages/ui/tests/permissions.test.ts
+++ b/packages/ui/tests/permissions.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+  API_KEY_SCOPE_VALUES,
+  MEMBER_PERMISSION_SCOPE_VALUES,
+  ORGANIZATION_MANAGEMENT_SCOPE_VALUES,
+} from "@cplane/migrations/utils";
+import {
+  denyAddMember,
+  denyAssignPermissions,
+  denyCreateInvitation,
+  denyDeleteOrganization,
+  denyRemoveMember,
+  denyRenameOrganization,
+  denyRevokeInvitation,
+  denyUpdateMemberRole,
+  hasScope,
+  isOwner,
+} from "../server/utils/permissions";
+
+const owner = (permissions: string[] = []) => ({ role: "owner", permissions });
+const member = (permissions: string[] = []) => ({ role: "member", permissions });
+
+describe("scope vocabulary parity", () => {
+  it("member permissions are a superset of the API-key scope vocabulary", () => {
+    for (const scope of API_KEY_SCOPE_VALUES) {
+      expect(MEMBER_PERMISSION_SCOPE_VALUES).toContain(scope);
+    }
+  });
+
+  it("API keys never carry org-management scopes", () => {
+    for (const management of ORGANIZATION_MANAGEMENT_SCOPE_VALUES) {
+      expect(API_KEY_SCOPE_VALUES).not.toContain(management);
+    }
+    for (const management of ORGANIZATION_MANAGEMENT_SCOPE_VALUES) {
+      expect(MEMBER_PERMISSION_SCOPE_VALUES).toContain(management);
+    }
+  });
+});
+
+describe("member-specific permissions", () => {
+  it("owners hold every scope implicitly", () => {
+    for (const scope of MEMBER_PERMISSION_SCOPE_VALUES) {
+      expect(hasScope(owner(), scope)).toBe(true);
+    }
+    expect(isOwner(owner())).toBe(true);
+  });
+
+  it("members only hold what was granted", () => {
+    const alice = member(["container:read", "bucket:create"]);
+    expect(hasScope(alice, "container:read")).toBe(true);
+    expect(hasScope(alice, "bucket:create")).toBe(true);
+    expect(hasScope(alice, "project:delete")).toBe(false);
+    expect(hasScope(alice, "org:update")).toBe(false);
+    expect(hasScope(member(), "container:read")).toBe(false);
+  });
+});
+
+describe("organization deletion", () => {
+  it("is owner-only", () => {
+    expect(denyDeleteOrganization(owner())).toBeNull();
+    expect(denyDeleteOrganization(member(["org:update", "api-key:manage"]))).toMatch(
+      /only organization owners/i,
+    );
+  });
+});
+
+describe("rename organization", () => {
+  it("requires org:update or ownership", () => {
+    expect(denyRenameOrganization(owner())).toBeNull();
+    expect(denyRenameOrganization(member(["org:update"]))).toBeNull();
+    expect(denyRenameOrganization(member(["registry:delete"]))).not.toBeNull();
+  });
+});
+
+describe("invitation permissions", () => {
+  it("validates that only owner or member roles are accepted", () => {
+    const inviter = member(["member:invite"]);
+    expect(denyCreateInvitation(inviter, "admin")).toMatch(/owner or member/i);
+    expect(denyCreateInvitation(inviter, "superuser")).toMatch(/owner or member/i);
+    expect(denyCreateInvitation(inviter, undefined)).toMatch(/owner or member/i);
+    expect(denyCreateInvitation(inviter, "member")).toBeNull();
+  });
+
+  it("requires member:invite to invite at all", () => {
+    expect(denyCreateInvitation(member([]), "member")).toMatch(/member:invite/);
+    expect(denyCreateInvitation(owner(), "member")).toBeNull();
+  });
+
+  it("never lets a non-owner create an owner invitation", () => {
+    expect(denyCreateInvitation(member(["member:invite"]), "owner")).toMatch(
+      /only owners can create owner invitations/i,
+    );
+    expect(denyCreateInvitation(owner(), "owner")).toBeNull();
+  });
+
+  it("revoking invitations requires member:invite", () => {
+    expect(denyRevokeInvitation(member(["member:invite"]))).toBeNull();
+    expect(denyRevokeInvitation(member())).not.toBeNull();
+    expect(denyRevokeInvitation(owner())).toBeNull();
+  });
+});
+
+describe("membership hierarchy and owner protection", () => {
+  const targetOwner = { role: "owner" };
+  const targetMember = { role: "member" };
+
+  it("members with member:remove may remove plain members only", () => {
+    const remover = member(["member:remove"]);
+    expect(denyRemoveMember(remover, targetMember, { isSelf: false, ownerCount: 1 })).toBeNull();
+    expect(
+      denyRemoveMember(remover, targetOwner, { isSelf: false, ownerCount: 2 }),
+    ).toMatch(/only owners can remove an owner/i);
+  });
+
+  it("members without member:remove cannot remove anyone", () => {
+    expect(
+      denyRemoveMember(member(["container:read"]), targetMember, { isSelf: false, ownerCount: 1 }),
+    ).toMatch(/member:remove/);
+  });
+
+  it("protects the final owner from removal", () => {
+    expect(
+      denyRemoveMember(owner(), targetOwner, { isSelf: false, ownerCount: 1 }),
+    ).toMatch(/last owner/i);
+    expect(
+      denyRemoveMember(owner(), targetOwner, { isSelf: false, ownerCount: 2 }),
+    ).toBeNull();
+  });
+
+  it("blocks self-removal through the removal action", () => {
+    expect(
+      denyRemoveMember(owner(), targetOwner, { isSelf: true, ownerCount: 2 }),
+    ).toMatch(/leave organization/i);
+  });
+
+  it("role changes stay owner-only with a final-owner guard", () => {
+    expect(
+      denyUpdateMemberRole(member(["org:update"]), "member", targetMember, {
+        isSelf: false,
+        ownerCount: 1,
+      }),
+    ).toMatch(/only owners can change member roles/i);
+
+    expect(
+      denyUpdateMemberRole(owner(), "admin", targetMember, { isSelf: false, ownerCount: 1 }),
+    ).toMatch(/owner or member/i);
+
+    expect(
+      denyUpdateMemberRole(owner(), "member", targetOwner, { isSelf: true, ownerCount: 1 }),
+    ).toMatch(/last owner/i);
+
+    expect(
+      denyUpdateMemberRole(owner(), "member", targetOwner, { isSelf: true, ownerCount: 2 }),
+    ).toBeNull();
+  });
+});
+
+describe("permission assignment", () => {
+  it("is owner-only", () => {
+    expect(denyAssignPermissions(owner(), targetMemberShape)).toBeNull();
+    expect(denyAssignPermissions(member(["org:update"]), targetMemberShape)).toMatch(
+      /only owners can manage member permissions/i,
+    );
+  });
+
+  it("owners cannot attach permissions to other owners", () => {
+    expect(denyAssignPermissions(owner(), targetOwnerShape)).toMatch(/members only/i);
+  });
+});
+
+// denyAssignPermissions takes {role} shapes; keep literals local for readability.
+const targetMemberShape = { role: "member" };
+const targetOwnerShape = { role: "owner" };
+
+describe("direct API bypass attempts (privileged endpoint manifest)", () => {
+  // Every privileged UI server endpoint and the decision that guards it.
+  // If a new privileged endpoint is added, register it here so it ships with its guard.
+  const privilegedEndpoints: Array<{
+    endpoint: string;
+    guard: (subject: { role: string; permissions: string[] }) => string | null;
+    bypassing: { role: string; permissions: string[] };
+  }> = [
+    {
+      endpoint: "DELETE /api/organization/:id",
+      guard: denyDeleteOrganization,
+      bypassing: member(["*"]),
+    },
+    {
+      endpoint: "PUT /api/organization/:id/name",
+      guard: denyRenameOrganization,
+      bypassing: member([]),
+    },
+    {
+      endpoint: "POST /api/organization/:id/members",
+      guard: denyAddMember,
+      bypassing: member([]),
+    },
+    {
+      endpoint: "DELETE /api/organization/:id/members/:member_id",
+      guard: (s) =>
+        denyRemoveMember(s, targetMemberShape, { isSelf: false, ownerCount: 2 }),
+      bypassing: member([]),
+    },
+    {
+      endpoint: "PATCH /api/organization/:id/members/:member_id",
+      guard: (s) =>
+        denyUpdateMemberRole(s, "member", targetMemberShape, { isSelf: false, ownerCount: 1 }),
+      bypassing: member(["member:remove"]),
+    },
+    {
+      endpoint: "PUT /api/organization/:id/members/:member_id/permissions",
+      guard: (s) => denyAssignPermissions(s, targetMemberShape),
+      bypassing: member(["member:invite", "member:remove"]),
+    },
+    {
+      endpoint: "POST /api/organization/:id/invitations",
+      guard: (s) => denyCreateInvitation(s, "member"),
+      bypassing: member([]),
+    },
+    {
+      endpoint: "DELETE /api/organization/:id/invitations/:invitation_id",
+      guard: denyRevokeInvitation,
+      bypassing: member([]),
+    },
+  ];
+
+  it.each(privilegedEndpoints)(
+    "$endpoint denies members lacking the required permission",
+    ({ guard, bypassing }) => {
+      expect(guard(bypassing)).not.toBeNull();
+      expect(guard(owner())).toBeNull();
+    }
+  );
+
+  it("no member scope subset unlocks owner-only endpoints", () => {
+    // A member granted *every* grantable scope still cannot delete the org
+    // or manage permissions — those are not scopes.
+    const maximallyPrivilegedMember = member([...MEMBER_PERMISSION_SCOPE_VALUES]);
+    expect(denyDeleteOrganization(maximallyPrivilegedMember)).not.toBeNull();
+    expect(denyAssignPermissions(maximallyPrivilegedMember, targetMemberShape)).not.toBeNull();
+    expect(
+      denyRemoveMember(maximallyPrivilegedMember, targetOwnerShape, {
+        isSelf: false,
+        ownerCount: 9,
+      }),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds organization-level RBAC and member-scoped permissions across the Rust API, Nuxt UI, and database schema.

## Changes

- Adds member permission scopes and a database migration.
- Enforces scoped and owner-only access in API middleware and server routes.
- Adds member role/permission management UI.
- Adds authorization tests covering owner protection and API bypasses.

closes #50, #60, #61, #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-based roles and permissions for members.
  * Owners can update member roles and manage permissions from Settings.
  * Organization and member responses now include assigned permissions.
  * Added permission-aware navigation and access controls for organization actions.
  * Added support for managing invitations, members, API keys, and organization settings based on granted permissions.

* **Security**
  * Strengthened organization isolation and owner-only protections across sensitive actions.
  * Added safeguards against removing the final owner or modifying owner permissions.

* **Tests**
  * Added coverage for role, scope, and organization authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->